### PR TITLE
Fix AMD acknowledgement alert rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # vLLM for AMD on Native Windows
 
 > [!IMPORTANT]
->
-> ## Thank you, AMD
+> **Thank you, AMD**
 >
 > AMD's Threadripper platform and Radeon AI PRO R9700 hardware made this
 > native-Windows ROCm project possible.


### PR DESCRIPTION
## What changed

Removed the blank blockquote line between `[!IMPORTANT]` and the AMD acknowledgement, and replaced the embedded heading with bold text.

## Root cause

GitHub alert directives must be followed immediately by alert content. The previous spacing was lint-valid but rendered as an ordinary blockquote instead of a colored Important alert.

## Impact

Documentation only. The acknowledgement now renders as the intended GitHub Important alert. No runtime, build, model-loading, or GPU-safety behavior changes.

## Safety review performed

- [x] Server-side scope will contain only `README.md`.
- [x] `git diff --check` passed.
- [x] `markdownlint-cli2 README.md` passed with zero issues.
- [x] All 17 PowerShell examples parsed successfully.
- [x] High-confidence credential signatures were not detected.
- [x] GitHub's Markdown API produced `markdown-alert-important` with bold `Thank you, AMD` content.