### PR TITLE
Add automated Windows ROCm setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,32 @@ Set-Location C:\AI\vllm
 
 A short path matters when Torch/Inductor generates deeply nested cache names.
 
+### Automated setup (recommended)
+
+After installing the system tools and cloning the repository, run the
+repository-local setup from PowerShell:
+
+```powershell
+Set-ExecutionPolicy -Scope Process Bypass
+.\setup_windows_rocm.ps1 -PlanOnly
+.\setup_windows_rocm.ps1
+```
+
+`-PlanOnly` checks Windows, the AMD adapter, Git, `uv`, Visual Studio, system
+RAM, disk headroom, and repository files without installing packages, opening a
+GPU context, or building anything. The full run then:
+
+1. Creates or reuses `.venv211` with Python 3.12.
+2. Installs the exact ROCm 7.13, PyTorch 2.11, and Triton packages below.
+3. Verifies Torch/HIP and requires `gfx1201` through the fail-closed VRAM guard.
+4. Builds and editable-installs the native Windows ROCm extensions.
+5. Runs a second guarded vLLM import and device verification.
+
+The script never downloads or launches a model. It does not silently install or
+update the AMD driver, Visual Studio, Git, or `uv`; review and install those
+system-wide prerequisites yourself. The manual commands below remain available
+for troubleshooting and auditing the automated process.
+
 ### 3. Create the serving environment
 
 ```powershell
@@ -585,6 +611,7 @@ VRAM, and throughput tests.
 
 | File | Purpose |
 | --- | --- |
+| `setup_windows_rocm.ps1` | Checks prerequisites, installs the pinned environment, runs guarded GPU probes, builds, and verifies the fork. |
 | `env_windows_rocm.cmd` | Shared Visual Studio, ROCm, compiler, and architecture environment. |
 | `build_windows_rocm.cmd` | Builds vLLM's C++/HIP extensions in place. |
 | `install_windows_rocm.cmd` | Installs this source tree into `.venv211` without replacing ROCm Torch. |

--- a/setup_windows_rocm.ps1
+++ b/setup_windows_rocm.ps1
@@ -1,0 +1,404 @@
+<#
+.SYNOPSIS
+    Prepare, build, and verify the tested native-Windows ROCm vLLM stack.
+
+.DESCRIPTION
+    Automates the repository-local parts of the Windows ROCm installation:
+
+    - validates the required Windows, AMD, uv, Git, and Visual Studio setup;
+    - creates or reuses .venv211 with Python 3.12;
+    - installs the pinned AMD ROCm/PyTorch, Triton, and build dependencies;
+    - probes the AMD GPU through vram_guard.ps1 and requires gfx1201;
+    - builds and editable-installs this vLLM fork; and
+    - performs a second guarded import/device verification.
+
+    It deliberately does not install or update the AMD display driver, Visual
+    Studio, Git, uv, or model weights. System-wide installers require explicit
+    user review, and models have separate licenses and storage requirements.
+
+.PARAMETER MaxJobs
+    Maximum parallel native build jobs. Defaults to 16.
+
+.PARAMETER GuardLimitGiB
+    Dedicated-VRAM kill threshold used for the guarded GPU probes.
+
+.PARAMETER GuardWarnGiB
+    Dedicated-VRAM warning threshold used for the guarded GPU probes.
+
+.PARAMETER PlanOnly
+    Validate system prerequisites and print the planned work without changing
+    the environment, downloading packages, probing the GPU, or building vLLM.
+
+.EXAMPLE
+    .\setup_windows_rocm.ps1 -PlanOnly
+
+.EXAMPLE
+    .\setup_windows_rocm.ps1
+#>
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param(
+    [ValidateRange(1, 256)]
+    [int]$MaxJobs = 16,
+
+    [ValidateRange(1.0, 256.0)]
+    [double]$GuardLimitGiB = 26.0,
+
+    [ValidateRange(0.0, 256.0)]
+    [double]$GuardWarnGiB = 23.0,
+
+    [switch]$PlanOnly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$ExpectedPython = '3.12'
+$ExpectedGpuArch = 'gfx1201'
+$TorchVersion = '2.11.0+rocm7.13.0'
+$TorchvisionVersion = '0.26.0+rocm7.13.0'
+$RocmVersion = '7.13.0'
+$TritonVersion = '3.6.0.post26'
+$AmdWheelIndex = 'https://repo.amd.com/rocm/whl/gfx120X-all/'
+
+$Root = (Resolve-Path -LiteralPath $PSScriptRoot).Path.TrimEnd('\')
+$Venv = Join-Path $Root '.venv211'
+$VenvPython = Join-Path $Venv 'Scripts\python.exe'
+$Requirements = Join-Path $Root 'requirements\common.txt'
+$BuildScript = Join-Path $Root 'build_windows_rocm.cmd'
+$InstallScript = Join-Path $Root 'install_windows_rocm.cmd'
+$GuardScript = Join-Path $Root 'vram_guard.ps1'
+$Vcvars = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat'
+
+function Write-Step([string]$Message) {
+    Write-Host "`n=== $Message ===" -ForegroundColor Cyan
+}
+
+function Write-Detail([string]$Name, [string]$Value) {
+    Write-Host ('{0,-18} {1}' -f ($Name + ':'), $Value)
+}
+
+function Invoke-Native(
+    [string]$Description,
+    [string]$FilePath,
+    [string[]]$ArgumentList
+) {
+    Write-Step $Description
+    & $FilePath @ArgumentList
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw "$Description failed with exit code $exitCode."
+    }
+}
+
+function Get-RequiredApplication([string]$Name, [string]$InstallHint) {
+    $command = Get-Command $Name -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($null -eq $command) {
+        throw "$Name was not found on PATH. $InstallHint"
+    }
+    return $command.Source
+}
+
+function Invoke-GuardedProbe([string]$Name, [string]$PythonCode) {
+    $logs = Join-Path $Root 'logs'
+    [void](New-Item -ItemType Directory -Path $logs -Force)
+
+    $stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $safeName = $Name.ToLowerInvariant().Replace(' ', '-')
+    $probeLog = Join-Path $logs "setup-$safeName-$stamp.log"
+    $guardLog = Join-Path $logs "setup-$safeName-$stamp.guard.log"
+    $probeFile = Join-Path ([IO.Path]::GetTempPath()) (
+        'vllm-windows-rocm-probe-{0}.py' -f [guid]::NewGuid().ToString('N')
+    )
+
+    [IO.File]::WriteAllText(
+        $probeFile,
+        $PythonCode,
+        [Text.UTF8Encoding]::new($false)
+    )
+
+    try {
+        $command = '"{0}" "{1}" > "{2}" 2>&1' -f (
+            $VenvPython,
+            $probeFile,
+            $probeLog
+        )
+
+        Write-Step "$Name (guarded)"
+        & $GuardScript `
+            -Command $command `
+            -LimitGiB $GuardLimitGiB `
+            -WarnGiB $GuardWarnGiB `
+            -StallLogPath $probeLog `
+            -StallSec 180 `
+            -LogPath $guardLog
+        $exitCode = $LASTEXITCODE
+
+        if (Test-Path -LiteralPath $probeLog) {
+            Get-Content -LiteralPath $probeLog
+        }
+        if ($exitCode -ne 0) {
+            throw "$Name failed under the VRAM guard with exit code $exitCode. See $guardLog"
+        }
+    }
+    finally {
+        Remove-Item -LiteralPath $probeFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Step 'Preflight checks'
+
+if ($env:OS -ne 'Windows_NT') {
+    throw 'This setup script supports native 64-bit Windows only.'
+}
+if (-not [Environment]::Is64BitOperatingSystem -or
+    -not [Environment]::Is64BitProcess) {
+    throw 'Run this script from a 64-bit PowerShell process on 64-bit Windows.'
+}
+if ($GuardWarnGiB -ge $GuardLimitGiB) {
+    throw 'GuardWarnGiB must be lower than GuardLimitGiB.'
+}
+
+$requiredFiles = @(
+    $Requirements,
+    $BuildScript,
+    $InstallScript,
+    $GuardScript,
+    (Join-Path $Root 'env_windows_rocm.cmd'),
+    (Join-Path $Root 'pyproject.toml')
+)
+foreach ($path in $requiredFiles) {
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "The clone is incomplete; required file is missing: $path"
+    }
+}
+if (-not (Test-Path -LiteralPath (Join-Path $Root '.git'))) {
+    throw @"
+Git metadata is missing. Clone the repository with Git instead of downloading
+a source ZIP so versioning and editable installation have the expected history.
+"@
+}
+
+$uv = Get-RequiredApplication 'uv' `
+    'Install it from https://docs.astral.sh/uv/getting-started/installation/'
+$git = Get-RequiredApplication 'git' `
+    'Install Git for Windows, reopen PowerShell, and try again.'
+
+if (-not (Test-Path -LiteralPath $Vcvars -PathType Leaf)) {
+    throw @"
+Visual Studio 2022 Build Tools was not found at the path expected by
+env_windows_rocm.cmd:
+  $Vcvars
+Install the Desktop development with C++ workload, MSVC v143, and a Windows
+10 or 11 SDK. Reopen PowerShell after installation.
+"@
+}
+
+$amdAdapters = @()
+try {
+    $amdAdapters = @(Get-CimInstance Win32_VideoController |
+        Where-Object { $_.Name -match 'AMD|Radeon' })
+}
+catch {
+    Write-Warning "Could not query display adapters: $($_.Exception.Message)"
+}
+if ($amdAdapters.Count -eq 0) {
+    throw 'No AMD/Radeon display adapter was detected. Install the matching AMD driver first.'
+}
+
+if ($Root.Length -gt 80) {
+    Write-Warning "The clone path is long ($($Root.Length) characters). C:\AI\vllm is recommended."
+}
+
+try {
+    $system = Get-CimInstance Win32_ComputerSystem
+    $ramGiB = [math]::Round($system.TotalPhysicalMemory / 1GB, 1)
+    if ($ramGiB -lt 32) {
+        Write-Warning "Only $ramGiB GiB of system RAM was detected; 32 GiB is the practical minimum."
+    }
+}
+catch {
+    $ramGiB = 'unknown'
+    Write-Warning "Could not query system RAM: $($_.Exception.Message)"
+}
+
+try {
+    $rootItem = Get-Item -LiteralPath $Root
+    $drive = Get-PSDrive -Name $rootItem.PSDrive.Name
+    $freeGiB = [math]::Round($drive.Free / 1GB, 1)
+    if ($freeGiB -lt 25) {
+        Write-Warning "Only $freeGiB GiB is free on $($drive.Name):; builds and wheels need headroom."
+    }
+}
+catch {
+    $freeGiB = 'unknown'
+    Write-Warning "Could not query free disk space: $($_.Exception.Message)"
+}
+
+Write-Detail 'Repository' $Root
+Write-Detail 'Expected GPU' $ExpectedGpuArch
+Write-Detail 'AMD adapter' (($amdAdapters | ForEach-Object Name) -join '; ')
+Write-Detail 'System RAM GiB' ([string]$ramGiB)
+Write-Detail 'Free disk GiB' ([string]$freeGiB)
+Write-Detail 'uv' $uv
+Write-Detail 'Git' $git
+Write-Detail 'Virtual env' $Venv
+Write-Detail 'Build jobs' ([string]$MaxJobs)
+Write-Detail 'VRAM guard' "$GuardWarnGiB GiB warn / $GuardLimitGiB GiB kill"
+
+if ($PlanOnly) {
+    Write-Step 'Plan'
+    Write-Host '1. Create or reuse .venv211 with Python 3.12.'
+    Write-Host '2. Install the pinned ROCm 7.13, PyTorch 2.11, and Triton stack.'
+    Write-Host '3. Run a fail-closed guarded Torch/HIP/gfx1201 probe.'
+    Write-Host '4. Build the native C++/HIP extensions with clang-cl.'
+    Write-Host '5. Editable-install vLLM and run a guarded import/device probe.'
+    Write-Host "`nPlanOnly completed; no files, packages, GPU contexts, or builds were changed."
+    return
+}
+
+if (-not (Test-Path -LiteralPath $VenvPython -PathType Leaf)) {
+    if (Test-Path -LiteralPath $Venv) {
+        throw @"
+$Venv exists but Scripts\python.exe is missing. Refusing to overwrite an
+ambiguous environment. Rename or remove only that directory after reviewing
+its contents, then rerun this script.
+"@
+    }
+    Invoke-Native `
+        'Create Python 3.12 virtual environment' `
+        $uv `
+        @('venv', '--python', $ExpectedPython, $Venv)
+}
+else {
+    Write-Step 'Reuse existing virtual environment'
+    Write-Host $Venv
+}
+
+$pythonVersion = & $VenvPython -c `
+    'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")'
+if ($LASTEXITCODE -ne 0 -or $pythonVersion.Trim() -ne $ExpectedPython) {
+    throw "$Venv must contain Python $ExpectedPython; found '$pythonVersion'."
+}
+
+$uvPip = @('pip', 'install', '--python', $VenvPython)
+
+Invoke-Native `
+    'Install pinned AMD ROCm and PyTorch wheels' `
+    $uv `
+    ($uvPip + @(
+        '--extra-index-url', $AmdWheelIndex,
+        '--index-strategy', 'unsafe-best-match',
+        "torch==$TorchVersion",
+        "torchvision==$TorchvisionVersion",
+        "rocm[devel]==$RocmVersion"
+    ))
+
+Invoke-Native `
+    'Install pinned Triton runtime' `
+    $uv `
+    ($uvPip + @(
+        "triton-windows==$TritonVersion",
+        'winloop'
+    ))
+
+Invoke-Native `
+    'Install core vLLM Python requirements' `
+    $uv `
+    ($uvPip + @('-r', $Requirements))
+
+Invoke-Native `
+    'Install native build requirements' `
+    $uv `
+    ($uvPip + @(
+        'cmake==4.4.2',
+        'ninja',
+        'packaging>=24.2',
+        'setuptools>=77,<80',
+        'setuptools-scm>=8',
+        'setuptools-rust>=1.9',
+        'wheel',
+        'jinja2>=3.1.6'
+    ))
+
+$torchProbe = @"
+import json
+import torch
+
+if not torch.cuda.is_available():
+    raise SystemExit('Torch cannot see an AMD GPU through HIP.')
+if torch.version.hip is None:
+    raise SystemExit('This is not a ROCm/HIP PyTorch build.')
+
+properties = torch.cuda.get_device_properties(0)
+architecture = str(properties.gcnArchName)
+architecture_base = architecture.split(':', 1)[0]
+result = {
+    'torch': torch.__version__,
+    'hip': torch.version.hip,
+    'device': torch.cuda.get_device_name(0),
+    'architecture': architecture,
+}
+print(json.dumps(result, sort_keys=True))
+
+if architecture_base != '$ExpectedGpuArch':
+    raise SystemExit(
+        f'Expected $ExpectedGpuArch, but Torch reported {architecture}. '
+        'This setup script only automates the tested R9700/RDNA4 target.'
+    )
+"@
+Invoke-GuardedProbe -Name 'ROCm device verification' -PythonCode $torchProbe
+
+$previousMaxJobs = [Environment]::GetEnvironmentVariable('MAX_JOBS', 'Process')
+$previousVllmRoot = [Environment]::GetEnvironmentVariable('VLLM_ROOT', 'Process')
+try {
+    $env:MAX_JOBS = [string]$MaxJobs
+    $env:VLLM_ROOT = $Root + '\'
+
+    Invoke-Native `
+        'Build vLLM native Windows ROCm extensions' `
+        $BuildScript `
+        @()
+
+    Invoke-Native `
+        'Editable-install this vLLM fork' `
+        $InstallScript `
+        @()
+}
+finally {
+    [Environment]::SetEnvironmentVariable(
+        'MAX_JOBS',
+        $previousMaxJobs,
+        'Process'
+    )
+    [Environment]::SetEnvironmentVariable(
+        'VLLM_ROOT',
+        $previousVllmRoot,
+        'Process'
+    )
+}
+
+$installProbe = @"
+import json
+import torch
+import vllm
+
+properties = torch.cuda.get_device_properties(0)
+print(json.dumps({
+    'vllm': vllm.__version__,
+    'torch': torch.__version__,
+    'hip': torch.version.hip,
+    'device': torch.cuda.get_device_name(0),
+    'architecture': str(properties.gcnArchName),
+}, sort_keys=True))
+"@
+Invoke-GuardedProbe -Name 'Installed vLLM verification' -PythonCode $installProbe
+
+Write-Step 'Setup complete'
+Write-Host 'The tested native-Windows ROCm vLLM environment is installed.'
+Write-Host 'No model was downloaded or launched.'
+Write-Host 'Next: follow README.md -> Choosing and downloading a model, then use'
+Write-Host 'vram_guard.ps1 around every serve or benchmark command.'


### PR DESCRIPTION
## What changed

- Added `setup_windows_rocm.ps1`, a repository-local setup orchestrator for the tested native-Windows ROCm stack.
- Added a recommended automated-setup section to the README and listed the new script in the repository script reference.

## Why

The existing instructions were reproducible but required users to manually execute several environment, dependency, GPU-verification, build, and install steps. The new script makes the supported R9700/`gfx1201` path easier to follow without hiding system-wide prerequisites or weakening the VRAM safeguards.

## User impact

After installing the AMD driver, Visual Studio Build Tools, Git, and `uv`, users can run:

```powershell
Set-ExecutionPolicy -Scope Process Bypass
.\setup_windows_rocm.ps1 -PlanOnly
.\setup_windows_rocm.ps1
```

The script creates or reuses `.venv211`, installs the pinned ROCm/PyTorch/Triton stack, performs fail-closed guarded GPU probes, builds and editable-installs vLLM, and verifies the installed fork. It does not download or launch a model.

## Safety behavior

- Requires native 64-bit Windows, an AMD adapter, a real Git clone, `uv`, Git, and the expected Visual Studio C++ toolchain.
- Refuses invalid VRAM warning/kill thresholds.
- Requires the tested `gfx1201` architecture.
- Runs both Torch/vLLM GPU probes through `vram_guard.ps1`.
- Refuses to overwrite an ambiguous `.venv211`.
- Temporarily pins and then restores `VLLM_ROOT` and `MAX_JOBS`.
- Does not install system-wide tools, drivers, or model weights.

## Validation

- [x] Windows PowerShell 5.1 parser passed.
- [x] `-PlanOnly` passed on the tested Threadripper/Radeon AI PRO R9700 system and left the worktree unchanged.
- [x] Invalid guard thresholds failed closed with exit code 1 and an actionable message.
- [x] All 18 README PowerShell blocks parsed successfully.
- [x] `markdownlint-cli2 README.md` passed with zero issues.
- [x] `git diff --check` passed.
- [x] High-confidence credential signatures were not detected in either changed file.
- [x] No recursive deletion, broad process killing, `Invoke-Expression`, or `requirements/rocm.txt` installation was introduced.

The full installer was not executed against the existing `.venv211`, because doing so would intentionally reinstall packages and rebuild native extensions. Its build/install entry points are the already tested repository scripts.