### PR TITLE
Enable RDNA W4A16 for native AWQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,8 @@ See the official [Hugging Face authentication documentation](https://huggingface
 | GPT-OSS MXFP4 | Supported through vLLM's built-in Triton MXFP4 MoE path. |
 | FP8 compressed-tensors | Supported, but graph replay can hang on some larger FP8 shapes; start with `cudagraph_mode=NONE`. |
 | FP8 KV cache | Supported and roughly halves KV memory. Validate output quality because untuned default scales can affect accuracy. |
-| AWQ/GPTQ INT4 | Do not assume a fast or working `gfx1201` kernel. This remains kernel-dependent. |
+| AWQ INT4 | Native 4-bit AWQ Safetensors with group size 32/64/128 use the hybrid RDNA W4A16 path on gfx11/gfx12: HIP skinny GEMM for decode and tuned Triton GEMM for larger batches. `Qwen/Qwen3-4B-AWQ` is validated on gfx1201. |
+| GPTQ INT4 | Kernel-dependent. The native AWQ validation does not establish that every GPTQ packing or activation-order configuration works on gfx1201. |
 | GGUF | Not included in core vLLM here. The official GGUF path is an out-of-tree plugin, which this project does not install. Prefer native Safetensors checkpoints. |
 | `trust_remote_code` models | Potentially supported, but review the repository code first. Never enable the flag for an untrusted model. |
 
@@ -604,8 +605,11 @@ VRAM, and throughput tests.
   1. The throughput runner exits cleanly.
 - **Vulkan is not a fallback:** if ROCm fails, installing Vulkan does not repair
   this vLLM backend.
-- **INT4 is kernel-dependent:** AWQ/GPTQ model size alone is not proof that its
-  CUDA-oriented kernel has a correct, fast RDNA4 path.
+- **AWQ compatibility is format-specific:** validated native AWQ uses 4-bit
+  weights, group size 32/64/128, FP16/BF16 activations, and no activation-order
+  index. Set `VLLM_ROCM_USE_RDNA_W4A16=0` to fall back to generic AutoAWQ while
+  diagnosing an unsupported checkpoint. GPTQ and other INT4 layouts remain
+  kernel-dependent.
 
 ## Repository scripts
 

--- a/WINDOWS_ROCM_PERFORMANCE.md
+++ b/WINDOWS_ROCM_PERFORMANCE.md
@@ -68,6 +68,27 @@ frontend exits with status 1 despite successful inference. The throughput
 runner exits cleanly; these are frontend compatibility issues, not a model or
 ROCm failure.
 
+### Native AWQ INT4
+
+`Qwen/Qwen3-4B-AWQ` works from its official 2.48 GiB Safetensors checkpoint
+without a GGUF plugin. On gfx1201, compatible native AWQ layers are converted
+to the modular packed format and select `RDNAHybridW4A16LinearKernel`: HIP
+skinny W4A16 for decode batches up to five tokens and a gfx1201-tuned Triton
+W4A16 kernel for larger batches.
+
+With one random prompt, 64 input tokens, 16 output tokens, maximum model length
+512, `--gpu-memory-utilization 0.40`, and `cudagraph_mode=NONE`, the repeated
+run produced 65.80 output tokens/s and peaked at 16.35 GiB. The earlier generic
+AutoAWQ path produced 30.45 output tokens/s with the same workload. These
+single-request measurements are sensitive to first-shape Triton JIT; use a
+repeated run and a representative serving workload before drawing broader
+throughput conclusions. Deterministic offline generation produced coherent
+text through the hybrid path.
+
+The hybrid path is enabled by default for 4-bit AWQ group sizes 32, 64, and
+128 on gfx11/gfx12. Set `VLLM_ROCM_USE_RDNA_W4A16=0` to retain generic AutoAWQ
+for compatibility diagnosis.
+
 ## Launcher settings
 
 `bench_windows_rocm.cmd` and `serve_windows_rocm.cmd` keep the conservative

--- a/tests/quantization/test_auto_awq.py
+++ b/tests/quantization/test_auto_awq.py
@@ -169,6 +169,66 @@ class TestAutoAWQConfigOverrideLogic:
         ), "from_config should set quant_method='awq' in full_config"
 
 
+class TestAutoAWQROCmKernelRouting:
+    """Tests for native AWQ routing into modular RDNA W4A16 kernels."""
+
+    @staticmethod
+    def _get_method(
+        monkeypatch,
+        *,
+        on_gfx1x: bool,
+        group_size: int = 128,
+        use_rdna_w4a16: bool = True,
+    ):
+        import vllm.model_executor.layers.quantization.auto_awq as auto_awq
+
+        class DummyLinear:
+            pass
+
+        monkeypatch.setattr(auto_awq, "LinearBase", DummyLinear)
+        monkeypatch.setattr(auto_awq.current_platform, "is_xpu", lambda: False)
+        monkeypatch.setattr(auto_awq.current_platform, "is_cpu", lambda: False)
+        monkeypatch.setattr(auto_awq.current_platform, "is_rocm", lambda: True)
+        monkeypatch.setattr(auto_awq.current_platform, "is_cuda", lambda: False)
+        monkeypatch.setattr("vllm.platforms.rocm.on_gfx1x", lambda: on_gfx1x)
+        monkeypatch.setattr(auto_awq, "verify_marlin_supported", lambda **kwargs: None)
+        monkeypatch.setattr(
+            auto_awq.envs,
+            "VLLM_ROCM_USE_RDNA_W4A16",
+            use_rdna_w4a16,
+        )
+
+        config = auto_awq.AutoAWQConfig(
+            weight_bits=4,
+            group_size=group_size,
+            zero_point=True,
+            lm_head_quantized=False,
+        )
+        return auto_awq, config.get_quant_method(DummyLinear(), "model.q_proj")
+
+    def test_gfx1x_uses_modular_w4a16_method(self, monkeypatch):
+        auto_awq, method = self._get_method(monkeypatch, on_gfx1x=True)
+
+        assert isinstance(method, auto_awq.AutoAWQMarlinLinearMethod)
+
+    def test_other_rocm_uses_generic_awq_fallback(self, monkeypatch):
+        auto_awq, method = self._get_method(monkeypatch, on_gfx1x=False)
+
+        assert isinstance(method, auto_awq.AutoAWQLinearMethod)
+
+    def test_unsupported_group_size_uses_generic_awq_fallback(self, monkeypatch):
+        auto_awq, method = self._get_method(monkeypatch, on_gfx1x=True, group_size=16)
+
+        assert isinstance(method, auto_awq.AutoAWQLinearMethod)
+
+    def test_disabled_rdna_w4a16_uses_generic_awq_fallback(self, monkeypatch):
+        auto_awq, method = self._get_method(
+            monkeypatch, on_gfx1x=True, use_rdna_w4a16=False
+        )
+
+        assert isinstance(method, auto_awq.AutoAWQLinearMethod)
+
+
 # =============================================================================
 # End-to-end integration tests (require GPU environment)
 # =============================================================================

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -116,6 +116,7 @@ if TYPE_CHECKING:
     VLLM_FORCE_AOT_LOAD: bool = False
     VLLM_USE_MEGA_AOT_ARTIFACT: bool = False
     VLLM_USE_TRITON_AWQ: bool = False
+    VLLM_ROCM_USE_RDNA_W4A16: bool = True
     VLLM_FASTSAFETENSORS_QUEUE_SIZE: int = 0
     VLLM_TRITON_FORCE_FIRST_CONFIG: bool = False
     VLLM_ALLOW_RUNTIME_LORA_UPDATING: bool = False
@@ -1131,6 +1132,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # If set, vLLM will use Triton implementations of AWQ.
     "VLLM_USE_TRITON_AWQ": lambda: bool(int(os.getenv("VLLM_USE_TRITON_AWQ", "0"))),
+    # Use the modular hybrid W4A16 kernel for compatible native AWQ models on
+    # RDNA3/RDNA4. Set to 0 to retain the generic AutoAWQ implementation.
+    "VLLM_ROCM_USE_RDNA_W4A16": lambda: bool(
+        int(os.getenv("VLLM_ROCM_USE_RDNA_W4A16", "1"))
+    ),
     # If set, monkey-patch triton.runtime.autotuner.Autotuner.run to skip
     # benchmarking and select the first valid config (walking past invalid
     # ones). Used to eliminate autotuning variability when measuring kernel

--- a/vllm/model_executor/layers/quantization/auto_awq.py
+++ b/vllm/model_executor/layers/quantization/auto_awq.py
@@ -305,6 +305,23 @@ class AutoAWQConfig(QuantizationConfig):
             if current_platform.is_cpu():
                 return AutoAWQMarlinLinearMethod(self)
 
+            # RDNA3/RDNA4 have a modular hybrid W4A16 kernel: a HIP skinny
+            # GEMM for decode and a tuned Triton GEMM for larger batches.
+            # Route compatible native AWQ checkpoints through the modular
+            # kernel selector so they can use that path after AWQ packing is
+            # converted to the standard MPLinearKernel format below. Keep the
+            # generic AWQ implementation as the fallback for other ROCm GPUs.
+            if current_platform.is_rocm():
+                from vllm.platforms.rocm import on_gfx1x
+
+                if (
+                    envs.VLLM_ROCM_USE_RDNA_W4A16
+                    and on_gfx1x()
+                    and self.weight_bits == 4
+                    and self.group_size in (32, 64, 128)
+                ):
+                    return AutoAWQMarlinLinearMethod(self)
+
             # Check if Marlin is supported and not using batch invariant mode
             # (Marlin kernels are not batch invariant)
             use_marlin = (


### PR DESCRIPTION
## What changed

- Route compatible native 4-bit AWQ checkpoints on gfx11/gfx12 through the existing modular `RDNAHybridW4A16LinearKernel`.
- Preserve generic AutoAWQ for non-RDNA ROCm devices and unsupported group sizes.
- Add `VLLM_ROCM_USE_RDNA_W4A16=0` as a compatibility fallback.
- Add routing tests and document the validated Windows RDNA4 behavior.

## Why

Native AutoAWQ selected `AutoAWQLinearMethod` directly, bypassing the modular linear-kernel selector. The optimized HIP-skinny/Triton hybrid W4A16 implementation was already present and tuned for gfx1201, but official AWQ checkpoints could not select it.

## Impact

On a Radeon AI PRO R9700 with `Qwen/Qwen3-4B-AWQ`, the identical guarded 64-input/16-output single-prompt workload improved from 30.65 to 65.80 output tokens/s (about 2.15x). Deterministic generation remained coherent. The optimized run peaked at 16.35 GiB dedicated VRAM and completed without a watchdog event.

## Validation

- Routing checks: gfx1x enabled, non-RDNA ROCm fallback, unsupported-group fallback, and explicit-disable fallback.
- Guarded real-model optimized and generic-fallback A/B runs.
- Guarded coherent-output generation.
- `ruff check` and `ruff format --check` pass.
- Python `compileall` passes.
- `git diff --check` and staged credential-pattern scan pass.

The runtime environment does not include the repository's complete pytest extras (`tblib` is missing), so full pytest collection was not run locally. Equivalent routing branches and real model execution were validated directly.
