### PR TITLE
Added gfx1200 Windows ROCm support

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -813,8 +813,8 @@ steps:
 
             # Download artifacts from current build
             echo "Downloading artifacts from current build"
-            # buildkite-agent artifact download "artifacts/rocm-base-wheels/*.whl" .
-            # buildkite-agent artifact download "artifacts/rocm-vllm-wheel/*.whl" .
+            buildkite-agent artifact download "artifacts/rocm-base-wheels/*.whl" .
+            buildkite-agent artifact download "artifacts/rocm-vllm-wheel/*.whl" .
 
             # # Run upload script
             bash .buildkite/scripts/upload-rocm-wheels.sh

--- a/.buildkite/scripts/build-macos-wheel.sh
+++ b/.buildkite/scripts/build-macos-wheel.sh
@@ -7,6 +7,9 @@
 
 set -euo pipefail
 
+# The macmini queue uses persistent checkouts, so refresh tags for setuptools-scm.
+git fetch --tags --force origin
+
 # The Rust frontend build needs protoc.
 if ! command -v protoc >/dev/null 2>&1; then
   brew install protobuf

--- a/.buildkite/test_areas/basic_correctness.yaml
+++ b/.buildkite/test_areas/basic_correctness.yaml
@@ -4,7 +4,7 @@ depends_on:
 steps:
 - label: Basic Correctness
   key: basic-correctness
-  timeout_in_minutes: 45
+  timeout_in_minutes: 68
   device: h200_18gb
   source_file_dependencies:
   - vllm/

--- a/.buildkite/test_areas/benchmarks.yaml
+++ b/.buildkite/test_areas/benchmarks.yaml
@@ -4,7 +4,7 @@ depends_on:
 steps:
 - label: Benchmarks CLI Test
   key: benchmarks-cli-test
-  timeout_in_minutes: 30
+  timeout_in_minutes: 45
   device: h200_18gb
   source_file_dependencies:
   - vllm/

--- a/.buildkite/test_areas/engine.yaml
+++ b/.buildkite/test_areas/engine.yaml
@@ -51,7 +51,7 @@ steps:
 
 - label: e2e Scheduling (1 GPU)
   key: e2e-scheduling-1-gpu
-  timeout_in_minutes: 35
+  timeout_in_minutes: 53
   device: h200_18gb
   source_file_dependencies:
     - vllm/v1/

--- a/.buildkite/test_areas/entrypoints.yaml
+++ b/.buildkite/test_areas/entrypoints.yaml
@@ -78,7 +78,7 @@ steps:
 - label: Entrypoints Integration (API Server OpenAI - Part 2)
   device: h200_35gb
   key: entrypoints-integration-api-server-openai-part-2
-  timeout_in_minutes: 45
+  timeout_in_minutes: 55
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/

--- a/.buildkite/test_areas/entrypoints.yaml
+++ b/.buildkite/test_areas/entrypoints.yaml
@@ -39,7 +39,7 @@ steps:
 - label: Entrypoints Integration (API Server)
   key: entrypoints-integration-api-server
   device: h200_35gb
-  timeout_in_minutes: 50
+  timeout_in_minutes: 75
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/
@@ -59,7 +59,7 @@ steps:
 - label: Entrypoints Integration (API Server OpenAI - Part 1)
   device: h200_35gb
   key: entrypoints-integration-api-server-openai-part-1
-  timeout_in_minutes: 45
+  timeout_in_minutes: 68
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/
@@ -78,7 +78,7 @@ steps:
 - label: Entrypoints Integration (API Server OpenAI - Part 2)
   device: h200_35gb
   key: entrypoints-integration-api-server-openai-part-2
-  timeout_in_minutes: 55
+  timeout_in_minutes: 83
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/
@@ -156,7 +156,7 @@ steps:
 - label: Entrypoints Integration (Pooling)
   device: h200_35gb
   key: entrypoints-integration-pooling
-  timeout_in_minutes: 50
+  timeout_in_minutes: 75
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -31,7 +31,7 @@ steps:
 
 - label: V1 Sample + Logits
   key: v1-sample-logits
-  timeout_in_minutes: 45
+  timeout_in_minutes: 55
   device: h200_18gb
   source_file_dependencies:
     - vllm/config/

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -31,7 +31,7 @@ steps:
 
 - label: V1 Sample + Logits
   key: v1-sample-logits
-  timeout_in_minutes: 55
+  timeout_in_minutes: 83
   device: h200_18gb
   source_file_dependencies:
     - vllm/config/

--- a/.buildkite/test_areas/model_executor.yaml
+++ b/.buildkite/test_areas/model_executor.yaml
@@ -5,7 +5,7 @@ steps:
 - label: Model Executor
   device: h200_35gb
   key: model-executor
-  timeout_in_minutes: 45
+  timeout_in_minutes: 60
   source_file_dependencies:
   - vllm/engine/arg_utils.py
   - vllm/config/model.py

--- a/.buildkite/test_areas/models_language.yaml
+++ b/.buildkite/test_areas/models_language.yaml
@@ -137,7 +137,7 @@ steps:
 
 - label: Language Models Test (MTEB)
   key: language-models-test-mteb
-  timeout_in_minutes: 45
+  timeout_in_minutes: 68
   device: h200_18gb
   optional: true
   source_file_dependencies:

--- a/.buildkite/test_areas/models_multimodal.yaml
+++ b/.buildkite/test_areas/models_multimodal.yaml
@@ -4,7 +4,7 @@ depends_on:
 steps:
 - label: "Multi-Modal Models (Standard) 1: qwen2"
   key: multi-modal-models-standard-1-qwen2
-  timeout_in_minutes: 45
+  timeout_in_minutes: 68
   device: h200_18gb
   source_file_dependencies:
   - vllm/
@@ -20,7 +20,7 @@ steps:
 
 - label: "Multi-Modal Models (Standard) 2: qwen3 + gemma"
   key: multi-modal-models-standard-2-qwen3-gemma
-  timeout_in_minutes: 50
+  timeout_in_minutes: 75
   device: h200_18gb
   source_file_dependencies:
   - vllm/
@@ -54,7 +54,7 @@ steps:
 - label: "Multi-Modal Models (Standard) 4: other + whisper"
   device: h200_35gb
   key: multi-modal-models-standard-4-other-whisper
-  timeout_in_minutes: 50
+  timeout_in_minutes: 75
   source_file_dependencies:
   - vllm/
   - tests/models/multimodal
@@ -85,7 +85,7 @@ steps:
 
 - label: Multi-Modal Processor # 44min
   key: multi-modal-processor
-  timeout_in_minutes: 65
+  timeout_in_minutes: 98
   device: h200_18gb
   source_file_dependencies:
   - vllm/

--- a/.buildkite/test_areas/pytorch.yaml
+++ b/.buildkite/test_areas/pytorch.yaml
@@ -5,7 +5,7 @@ steps:
 - label: PyTorch Compilation Unit Tests
   device: h200_35gb
   key: pytorch-compilation-unit-tests
-  timeout_in_minutes: 90
+  timeout_in_minutes: 110
   source_file_dependencies:
     - vllm/__init__.py
     - vllm/_aiter_ops.py

--- a/.buildkite/test_areas/pytorch.yaml
+++ b/.buildkite/test_areas/pytorch.yaml
@@ -5,7 +5,7 @@ steps:
 - label: PyTorch Compilation Unit Tests
   device: h200_35gb
   key: pytorch-compilation-unit-tests
-  timeout_in_minutes: 110
+  timeout_in_minutes: 150
   source_file_dependencies:
     - vllm/__init__.py
     - vllm/_aiter_ops.py

--- a/.gitignore
+++ b/.gitignore
@@ -257,3 +257,25 @@ vllm/grpc/vllm_engine_pb2.pyi
 
 # Ignore generated cpu headers 
 csrc/cpu/cpu_attn_dispatch_generated.h
+
+# Native Windows ROCm local state and generated artifacts
+/.triton_cache*/
+/logs/
+/profiles/
+/models/
+/checkpoints/
+*.safetensors
+*.gguf
+
+# Local credentials and private key material
+.env.*
+!.env.example
+/.secrets/
+/secrets/
+/credentials.json
+/service-account*.json
+/hf_token
+/*.pem
+/*.key
+/*.p12
+/*.pfx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,9 +52,16 @@ set(PYTHON_SUPPORTED_VERSIONS "3.10" "3.11" "3.12" "3.13" "3.14")
 set(HIP_SUPPORTED_ARCHS "gfx906;gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201")
 
 # ROCm installation prefix. Default to /opt/rocm but allow override via
-# -DROCM_PATH=/your/rocm/path when invoking cmake.
+# -DROCM_PATH=/your/rocm/path when invoking cmake, or via the ROCM_PATH
+# environment variable. The env var matters on Windows, where ROCm ships as
+# pip wheels (rocm-sdk-devel) with no fixed install location.
 if(NOT DEFINED ROCM_PATH)
-  set(ROCM_PATH "/opt/rocm" CACHE PATH "ROCm installation prefix")
+  if(DEFINED ENV{ROCM_PATH})
+    file(TO_CMAKE_PATH "$ENV{ROCM_PATH}" _VLLM_ENV_ROCM_PATH)
+    set(ROCM_PATH "${_VLLM_ENV_ROCM_PATH}" CACHE PATH "ROCm installation prefix")
+  else()
+    set(ROCM_PATH "/opt/rocm" CACHE PATH "ROCm installation prefix")
+  endif()
 else()
   set(ROCM_PATH ${ROCM_PATH} CACHE PATH "ROCm installation prefix" FORCE)
 endif()

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,21 @@
+vLLM for AMD on Native Windows
+
+This distribution is based on the vLLM project:
+https://github.com/vllm-project/vllm
+
+Upstream base: vLLM v0.26.0, commit 568afb3
+
+vLLM and this modified source distribution are provided under the Apache
+License, Version 2.0. See the LICENSE file in this repository.
+
+The native-Windows AMD changes include build-system portability, Windows
+process and networking compatibility, a single-rank distributed stand-in for
+Windows ROCm PyTorch, ROCm device-detection fallbacks, Windows launchers, and a
+dedicated-VRAM/stall watchdog. Modified files retain their upstream copyright
+and SPDX notices where present.
+
+This is a community-maintained fork.
+
+ROCm, PyTorch, Triton, Hugging Face models, and other third-party dependencies
+are separate works distributed under their respective licenses and notices.
+They are not relicensed by this repository's Apache-2.0 license.

--- a/README.md
+++ b/README.md
@@ -226,6 +226,154 @@ update the AMD driver, Visual Studio, Git, or `uv`; review and install those
 system-wide prerequisites yourself. The manual commands below remain available
 for troubleshooting and auditing the automated process.
 
+## Radeon RX 9000 quick start
+
+This section is the shortest supported path from a fresh clone to an
+OpenAI-compatible local server on an RX 9000-series GPU. AMD's Windows system
+requirements currently map the cards as follows:
+
+| GPU | Build target | Validation in this fork |
+| --- | --- | --- |
+| Radeon RX 9070 XT, RX 9070 GRE, RX 9070 | `gfx1201` | Architecture supported; the closely related Radeon AI PRO R9700 is the primary upstream test card |
+| Radeon RX 9060 XT LP, RX 9060 XT, RX 9060 | `gfx1200` | RX 9060 XT 16 GiB validated with Qwen3-0.6B |
+
+Check AMD's current [Windows system requirements](https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/shared/hipsdk/reference/system-requirements.html)
+before installing. A listed ROCm architecture does not guarantee that every
+vLLM model, quantization format, or optimized kernel works on that card.
+
+### 1. Install prerequisites and clone
+
+Install Python 3.12 x64, Git, `uv`, Visual Studio 2022 Build Tools with the
+Desktop C++ workload, CMake, Ninja, and a compatible AMD Radeon driver. Clone
+the repository into a short path on a drive with ample free space:
+
+```powershell
+git clone https://github.com/charlie12345/vLLM_for_AMD.git D:\AI\vllm
+Set-Location D:\AI\vllm
+Set-ExecutionPolicy -Scope Process Bypass
+```
+
+The ROCm development SDK, Python environment, download cache, and native build
+intermediates can consume tens of GiB. Keep at least 40 GiB free for the first
+installation when possible.
+
+### 2. Select the architecture and safety limits
+
+Choose the command matching the GPU. The examples assume a display-connected
+card and deliberately leave VRAM available for Windows.
+
+RX 9060 XT 16 GiB (`gfx1200`):
+
+```powershell
+.\setup_windows_rocm.ps1 -GpuArch gfx1200 -PlanOnly `
+  -MaxJobs 6 -GuardWarnGiB 13 -GuardLimitGiB 14.5
+.\setup_windows_rocm.ps1 -GpuArch gfx1200 `
+  -MaxJobs 6 -GuardWarnGiB 13 -GuardLimitGiB 14.5
+```
+
+RX 9060 8 GiB or RX 9060 XT 8 GiB (`gfx1200`):
+
+```powershell
+.\setup_windows_rocm.ps1 -GpuArch gfx1200 -PlanOnly `
+  -MaxJobs 6 -GuardWarnGiB 6.5 -GuardLimitGiB 7.25
+.\setup_windows_rocm.ps1 -GpuArch gfx1200 `
+  -MaxJobs 6 -GuardWarnGiB 6.5 -GuardLimitGiB 7.25
+```
+
+RX 9070-family 16 GiB (`gfx1201`):
+
+```powershell
+.\setup_windows_rocm.ps1 -GpuArch gfx1201 -PlanOnly `
+  -MaxJobs 6 -GuardWarnGiB 13 -GuardLimitGiB 14.5
+.\setup_windows_rocm.ps1 -GpuArch gfx1201 `
+  -MaxJobs 6 -GuardWarnGiB 13 -GuardLimitGiB 14.5
+```
+
+The full setup creates `.venv211`, installs the pinned ROCm/PyTorch/Triton
+stack, verifies the selected GPU architecture, compiles the native HIP
+extensions, and verifies the resulting vLLM installation. Do not activate or
+reuse an unrelated Python environment for this build.
+
+### 3. Download a small smoke-test model
+
+Start with a small BF16 model before trying a large or quantized checkpoint:
+
+```powershell
+.\.venv211\Scripts\Activate.ps1
+New-Item -ItemType Directory -Path .\models -Force | Out-Null
+.\.venv211\Scripts\hf.exe download Qwen/Qwen3-0.6B `
+  --local-dir .\models\Qwen3-0.6B
+```
+
+### 4. Start the guarded server
+
+Keep model, log, and compiler-cache files under the repository. For a 16 GiB
+card, run:
+
+```powershell
+$root = (Resolve-Path .).Path
+$model = Join-Path $root 'models\Qwen3-0.6B'
+$logs = Join-Path $root 'logs'
+New-Item -ItemType Directory -Path $logs -Force | Out-Null
+
+$env:VLLM_CACHE_ROOT = Join-Path $root '.cache\vllm'
+$env:TRITON_CACHE_DIR = Join-Path $root '.cache\triton'
+
+$serverLog = Join-Path $logs 'qwen3-0.6b-server.log'
+$guardLog = Join-Path $logs 'qwen3-0.6b-server.guard.log'
+$command = "`"$root\serve_windows_rocm.cmd`" `"$model`" " +
+  '--served-model-name qwen3-0.6b --host 127.0.0.1 --port 8000 ' +
+  '--max-model-len 2048 --gpu-memory-utilization 0.55 ' +
+  "-cc.cudagraph_mode=NONE > `"$serverLog`" 2>&1"
+
+& "$root\vram_guard.ps1" `
+  -Command $command `
+  -WarnGiB 13 `
+  -LimitGiB 14.5 `
+  -LogPath $guardLog
+```
+
+For an 8 GiB card, replace the guard thresholds with `6.5` and `7.25` and
+start with a lower `--gpu-memory-utilization`, such as `0.45`. Leave the guard
+terminal open. Initial model startup can spend several minutes compiling
+Triton kernels; wait until the log reports `Application startup complete`.
+
+### 5. Verify and send a chat request
+
+Open a second PowerShell window:
+
+```powershell
+(Invoke-WebRequest -UseBasicParsing http://127.0.0.1:8000/health).StatusCode
+
+$body = @{
+  model = 'qwen3-0.6b'
+  messages = @(
+    @{ role = 'user'; content = 'Write one sentence confirming that vLLM works.' }
+  )
+  max_tokens = 128
+  temperature = 0
+  chat_template_kwargs = @{ enable_thinking = $false }
+} | ConvertTo-Json -Depth 5
+
+$response = Invoke-RestMethod `
+  -Uri http://127.0.0.1:8000/v1/chat/completions `
+  -Method Post `
+  -ContentType 'application/json' `
+  -Body $body
+
+$response.choices[0].message.content
+```
+
+An HTTP `200` health result followed by generated text confirms the basic
+native-Windows ROCm path. This fork remains experimental, single-GPU only, and
+may fall back from a custom ROCm kernel to Triton on unsupported shapes or
+architectures.
+
+## Manual installation (advanced)
+
+The automated setup above is recommended. The following commands expose each
+installation and build step for troubleshooting or auditing.
+
 ### 3. Create the serving environment
 
 ```powershell
@@ -264,19 +412,23 @@ install the tested core serving stack while preserving AMD's ROCm Torch wheel.
   "import torch; print(torch.__version__); print(torch.version.hip); print(torch.cuda.get_device_name(0)); print(torch.cuda.get_device_properties(0).gcnArchName)"
 ```
 
-For the tested card, the final line must report `gfx1201`. Stop here if Torch
-cannot see the expected AMD GPU.
+The final line must match the selected target: `gfx1200` for the RX 9060 family
+or `gfx1201` for the RX 9070 family. Stop here if Torch cannot see the expected
+AMD GPU.
 
 ### 5. Build and install this fork
 
 ```powershell
+$env:VLLM_ROCM_GPU_ARCH = 'gfx1201' # Use gfx1200 for the RX 9060 family.
 .\build_windows_rocm.cmd
 .\install_windows_rocm.cmd
 ```
 
 These scripts load the Visual Studio environment, find ROCm through
 `python -m rocm_sdk path --root`, select `clang-cl` for both C++ and HIP, build
-for `gfx1201`, and install vLLM into `.venv211` in editable mode.
+for the architecture selected in `VLLM_ROCM_GPU_ARCH`, and install vLLM into
+`.venv211` in editable mode. If the variable is unset, the original `gfx1201`
+default is used.
 
 Verify the install without loading a model:
 

--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ results, profiles, and current kernel limitations.
 - An AMD GPU supported by the Windows ROCm/PyTorch release you install. Check
   AMD's current [Windows compatibility matrix](https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/compatibility/compatibilityrad/windows/windows_compatibility.html)
   and [HIP SDK system requirements](https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/shared/hipsdk/reference/system-requirements.html).
-- This branch is tested only on `gfx1201`: Radeon AI PRO R9700 and the same
-  RDNA4 target family.
+- This branch is validated on `gfx1201` (Radeon AI PRO R9700) and has also
+  completed a native-Windows model-serving smoke test on `gfx1200` (Radeon
+  RX 9060 XT). Other RDNA4 targets remain experimental.
 - Enough system RAM and disk for the checkpoint plus build intermediates.
   Thirty-two GiB of system RAM is a practical floor for smaller models; 64 GiB
   or more is recommended for larger checkpoints and source builds.
@@ -197,13 +198,26 @@ Set-ExecutionPolicy -Scope Process Bypass
 .\setup_windows_rocm.ps1
 ```
 
+For a Radeon RX 9060 XT (`gfx1200`, 16 GiB), select the architecture and use
+conservative build concurrency and VRAM limits:
+
+```powershell
+.\setup_windows_rocm.ps1 -GpuArch gfx1200 -PlanOnly `
+  -MaxJobs 6 -GuardWarnGiB 13 -GuardLimitGiB 14.5
+.\setup_windows_rocm.ps1 -GpuArch gfx1200 `
+  -MaxJobs 6 -GuardWarnGiB 13 -GuardLimitGiB 14.5
+```
+
+Omitting `-GpuArch` preserves the original `gfx1201` default.
+
 `-PlanOnly` checks Windows, the AMD adapter, Git, `uv`, Visual Studio, system
 RAM, disk headroom, and repository files without installing packages, opening a
 GPU context, or building anything. The full run then:
 
 1. Creates or reuses `.venv211` with Python 3.12.
 2. Installs the exact ROCm 7.13, PyTorch 2.11, and Triton packages below.
-3. Verifies Torch/HIP and requires `gfx1201` through the fail-closed VRAM guard.
+3. Verifies Torch/HIP and requires the selected GFX architecture through the
+   fail-closed VRAM guard.
 4. Builds and editable-installs the native Windows ROCm extensions.
 5. Runs a second guarded vLLM import and device verification.
 
@@ -560,27 +574,33 @@ on the repository as a second layer. If a real credential is ever committed,
 rotate or revoke it immediately; deleting the working-tree file does not remove
 it from Git history.
 
-## Building for a different AMD architecture
+## Selecting an AMD architecture
 
-The current `env_windows_rocm.cmd` contains two explicit `gfx1201` settings:
+The automated setup supports `gfx1201` (the default) and `gfx1200` through the
+`-GpuArch` parameter. It passes the selection consistently to
+`PYTORCH_ROCM_ARCH` and `CMAKE_HIP_ARCHITECTURES`:
 
-- `PYTORCH_ROCM_ARCH=gfx1201`
-- `-DCMAKE_HIP_ARCHITECTURES=gfx1201`
+```powershell
+.\setup_windows_rocm.ps1 -GpuArch gfx1200 -PlanOnly
+.\setup_windows_rocm.ps1 -GpuArch gfx1200
+```
 
-To experiment with another GPU:
+To experiment with an architecture outside those two validated options:
 
 1. Find its GFX target in AMD's support matrix or with a working ROCm Torch
    install.
 2. Install the matching AMD ROCm/PyTorch device wheels. Do not use `gfx120X-all`
    for an unrelated architecture.
-3. Change both build targets above to the same GFX value.
+3. Extend the `GpuArch` validation set, keeping the PyTorch and CMake targets
+   identical.
 4. Delete only the repository's generated build directory, rebuild, and start
    with a very small model under conservative guard limits.
 
 Architecture support in a ROCm wheel does not guarantee that every vLLM
-attention or quantization kernel supports that architecture. Treat all targets
-other than `gfx1201` as unverified until they pass model-load, coherent-output,
-VRAM, and throughput tests.
+attention or quantization kernel supports that architecture. The `gfx1200`
+smoke test used Qwen3-0.6B and fell back from the custom ROCm paged-attention
+kernel to Triton; broader model, quantization, VRAM, and throughput coverage is
+still required.
 
 ## Known limitations and troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,8 @@ See the official [Hugging Face authentication documentation](https://huggingface
 | GPT-OSS MXFP4 | Supported through vLLM's built-in Triton MXFP4 MoE path. |
 | FP8 compressed-tensors | Supported, but graph replay can hang on some larger FP8 shapes; start with `cudagraph_mode=NONE`. |
 | FP8 KV cache | Supported and roughly halves KV memory. Validate output quality because untuned default scales can affect accuracy. |
-| AWQ/GPTQ INT4 | Do not assume a fast or working `gfx1201` kernel. This remains kernel-dependent. |
+| AWQ INT4 | Native 4-bit AWQ Safetensors with group size 32/64/128 use the hybrid RDNA W4A16 path on gfx11/gfx12: HIP skinny GEMM for decode and tuned Triton GEMM for larger batches. `Qwen/Qwen3-4B-AWQ` is validated on gfx1201. |
+| GPTQ INT4 | Kernel-dependent. The native AWQ validation does not establish that every GPTQ packing or activation-order configuration works on gfx1201. |
 | GGUF | Not included in core vLLM here. The official GGUF path is an out-of-tree plugin, which this project does not install. Prefer native Safetensors checkpoints. |
 | `trust_remote_code` models | Potentially supported, but review the repository code first. Never enable the flag for an untrusted model. |
 
@@ -604,8 +605,11 @@ VRAM, and throughput tests.
   1. The throughput runner exits cleanly.
 - **Vulkan is not a fallback:** if ROCm fails, installing Vulkan does not repair
   this vLLM backend.
-- **INT4 is kernel-dependent:** AWQ/GPTQ model size alone is not proof that its
-  CUDA-oriented kernel has a correct, fast RDNA4 path.
+- **AWQ compatibility is format-specific:** validated native AWQ uses 4-bit
+  weights, group size 32/64/128, FP16/BF16 activations, and no activation-order
+  index. Set `VLLM_ROCM_USE_RDNA_W4A16=0` to fall back to generic AutoAWQ while
+  diagnosing an unsupported checkpoint. GPTQ and other INT4 layouts remain
+  kernel-dependent.
 
 ## Repository scripts
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # vLLM for AMD on Native Windows
 
 > [!IMPORTANT]
->
-> ## Thank you, AMD
+> **Thank you, AMD**
 >
 > AMD's Threadripper platform and Radeon AI PRO R9700 hardware made this
 > native-Windows ROCm project possible.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,12 @@ Linux VM, Docker container, CUDA translation layer, or GGUF plugin required.
 This is an experimental, community-maintained fork of
 [vLLM](https://github.com/vllm-project/vllm), currently based on vLLM v0.26.0.
 It is validated on Windows 11 with a Radeon AI PRO R9700 (RDNA4, `gfx1201`) and
-AMD's Windows ROCm/PyTorch wheels. It provides an OpenAI-compatible server,
-offline benchmarks, FP8/MXFP4 support where vLLM has a compatible kernel, and a
-fail-closed VRAM watchdog for desktop GPUs.
+a Radeon RX 9060 XT 16 GiB (RDNA4, `gfx1200`) using AMD's Windows ROCm/PyTorch
+wheels. RX 9060 XT validation includes a successful native build, Qwen3-0.6B
+model load, HTTP health check, and OpenAI-compatible chat completion, with
+paged attention falling back to Triton. The fork provides an OpenAI-compatible
+server, offline benchmarks, FP8/MXFP4 support where vLLM has a compatible
+kernel, and a fail-closed VRAM watchdog for desktop GPUs.
 
 > [!WARNING]
 > This is not an official AMD or vLLM release. The tested stack is version
@@ -31,7 +34,8 @@ fail-closed VRAM watchdog for desktop GPUs.
 | Item | Current status |
 | --- | --- |
 | Host OS | Native Windows 11 x64 |
-| Tested GPU | AMD Radeon AI PRO R9700, RDNA4 `gfx1201`, 32 GiB |
+| Primary validated GPU | AMD Radeon AI PRO R9700, RDNA4 `gfx1201`, 32 GiB |
+| Additional validated GPU | AMD Radeon RX 9060 XT, RDNA4 `gfx1200`, 16 GiB |
 | vLLM base | v0.26.0, base commit `568afb3` |
 | Python | 3.12.10 |
 | PyTorch | 2.11.0 + ROCm 7.13.0 |
@@ -42,9 +46,10 @@ fail-closed VRAM watchdog for desktop GPUs.
 | Model files | Hugging Face/Safetensors formats; no GGUF plugin included |
 | Vulkan | Not used by this vLLM backend |
 
-Other AMD architectures may work after selecting matching ROCm wheels and
-changing the build target, but they are not validated by this repository yet.
-The checked-in build environment currently targets `gfx1201` explicitly.
+The automated setup accepts `gfx1200` and `gfx1201` through `-GpuArch`, with
+`gfx1201` retained as the backward-compatible default. Other AMD architectures
+may work after selecting matching ROCm wheels and extending the build target,
+but they are not validated by this repository.
 
 ## Why this Windows port is different
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # vLLM for AMD on Native Windows
 
-**Thank you to AMD for the Threadripper platform and Radeon AI PRO R9700
-hardware that made this project possible.**
+> [!IMPORTANT]
+>
+> ## Thank you, AMD
+>
+> AMD's Threadripper platform and Radeon AI PRO R9700 hardware made this
+> native-Windows ROCm project possible.
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Windows%2011-0078D4)](#requirements)

--- a/README.md
+++ b/README.md
@@ -186,6 +186,32 @@ Set-Location C:\AI\vllm
 
 A short path matters when Torch/Inductor generates deeply nested cache names.
 
+### Automated setup (recommended)
+
+After installing the system tools and cloning the repository, run the
+repository-local setup from PowerShell:
+
+```powershell
+Set-ExecutionPolicy -Scope Process Bypass
+.\setup_windows_rocm.ps1 -PlanOnly
+.\setup_windows_rocm.ps1
+```
+
+`-PlanOnly` checks Windows, the AMD adapter, Git, `uv`, Visual Studio, system
+RAM, disk headroom, and repository files without installing packages, opening a
+GPU context, or building anything. The full run then:
+
+1. Creates or reuses `.venv211` with Python 3.12.
+2. Installs the exact ROCm 7.13, PyTorch 2.11, and Triton packages below.
+3. Verifies Torch/HIP and requires `gfx1201` through the fail-closed VRAM guard.
+4. Builds and editable-installs the native Windows ROCm extensions.
+5. Runs a second guarded vLLM import and device verification.
+
+The script never downloads or launches a model. It does not silently install or
+update the AMD driver, Visual Studio, Git, or `uv`; review and install those
+system-wide prerequisites yourself. The manual commands below remain available
+for troubleshooting and auditing the automated process.
+
 ### 3. Create the serving environment
 
 ```powershell
@@ -585,6 +611,7 @@ VRAM, and throughput tests.
 
 | File | Purpose |
 | --- | --- |
+| `setup_windows_rocm.ps1` | Checks prerequisites, installs the pinned environment, runs guarded GPU probes, builds, and verifies the fork. |
 | `env_windows_rocm.cmd` | Shared Visual Studio, ROCm, compiler, and architecture environment. |
 | `build_windows_rocm.cmd` | Builds vLLM's C++/HIP extensions in place. |
 | `install_windows_rocm.cmd` | Installs this source tree into `.venv211` without replacing ROCm Torch. |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # vLLM for AMD on Native Windows
 
+**Thank you to AMD for the Threadripper platform and Radeon AI PRO R9700
+hardware that made this project possible.**
+
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Windows%2011-0078D4)](#requirements)
 [![Accelerator](https://img.shields.io/badge/accelerator-AMD%20ROCm%2FHIP-ED1C24)](#how-it-works)
@@ -14,11 +17,6 @@ It is validated on Windows 11 with a Radeon AI PRO R9700 (RDNA4, `gfx1201`) and
 AMD's Windows ROCm/PyTorch wheels. It provides an OpenAI-compatible server,
 offline benchmarks, FP8/MXFP4 support where vLLM has a compatible kernel, and a
 fail-closed VRAM watchdog for desktop GPUs.
-
-> **Thank you to AMD** for the Threadripper platform and Radeon AI PRO R9700
-> hardware that made this native-Windows ROCm work possible.
-
-<!-- Separate the acknowledgement and warning callouts. -->
 
 > [!WARNING]
 > This is not an official AMD or vLLM release. The tested stack is version
@@ -58,8 +56,6 @@ evolve, so follow the links for their latest status.
 | Project | OS and accelerator | Architectural difference |
 | --- | --- | --- |
 | [Upstream vLLM](https://docs.vllm.ai/en/latest/getting_started/installation/gpu.html) | Official GPU requirements list Linux; no native Windows support | This is the source project. This fork adds native-Windows build and runtime compatibility while retaining its ROCm platform. |
-| [SystemPanic/vllm-windows](https://github.com/SystemPanic/vllm-windows) | Native Windows, NVIDIA CUDA | A Windows port centered on CUDA, CUDA libraries, and optional Windows NCCL. It is not an AMD ROCm port. |
-| [lemonade-sdk/vllm-rocm](https://github.com/lemonade-sdk/vllm-rocm) | AMD ROCm portable bundles for Linux/Lemonade | Ships a relocatable Linux runtime and explicitly requires a Linux kernel with `amdgpu`; it does not build this in-tree native-Windows fork. |
 | [ThePie88/vLLM-ROCm-Windows](https://github.com/ThePie88/vLLM-ROCm-Windows) | Native Windows, AMD ROCm, primarily tested on RDNA3 `gfx1100` | An out-of-tree vLLM platform plugin and compatibility layer. It installs upstream vLLM without its normal kernel build, then separately loads selected native/custom kernels. |
 | This repository | Native Windows, AMD ROCm, tested on RDNA4 `gfx1201` | An in-tree vLLM fork that builds vLLM's HIP extensions directly, patches Windows process/runtime assumptions, and ships safe AMD-tuned launchers plus a VRAM/stall watchdog. |
 

--- a/README.md
+++ b/README.md
@@ -1,110 +1,633 @@
-<!-- markdownlint-disable MD001 MD041 -->
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vllm-project/vllm/main/docs/assets/logos/vllm-logo-text-dark.png">
-    <img alt="vLLM" src="https://raw.githubusercontent.com/vllm-project/vllm/main/docs/assets/logos/vllm-logo-text-light.png" width=55%>
-  </picture>
-</p>
+# vLLM for AMD on Native Windows
 
-<h3 align="center">
-Easy, fast, and cheap LLM serving for everyone
-</h3>
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Platform](https://img.shields.io/badge/platform-Windows%2011-0078D4)](#requirements)
+[![Accelerator](https://img.shields.io/badge/accelerator-AMD%20ROCm%2FHIP-ED1C24)](#how-it-works)
+[![Status](https://img.shields.io/badge/status-experimental-orange)](#project-status)
 
-<p align="center">
-| <a href="https://docs.vllm.ai"><b>Documentation</b></a> | <a href="https://blog.vllm.ai/"><b>Blog</b></a> | <a href="https://arxiv.org/abs/2309.06180"><b>Paper</b></a> | <a href="https://x.com/vllm_project"><b>Twitter/X</b></a> | <a href="https://discuss.vllm.ai"><b>User Forum</b></a> | <a href="https://slack.vllm.ai"><b>Developer Slack</b></a> |
-</p>
+Run the real vLLM engine directly on an AMD GPU in native Windows: no WSL,
+Linux VM, Docker container, CUDA translation layer, or GGUF plugin required.
 
-🔥 We have built a vLLM website to help you get started with vLLM. Please visit [vllm.ai](https://vllm.ai) to learn more.
-For events, please visit [vllm.ai/events](https://vllm.ai/events) to join us.
+This is an experimental, community-maintained fork of
+[vLLM](https://github.com/vllm-project/vllm), currently based on vLLM v0.26.0.
+It is validated on Windows 11 with a Radeon AI PRO R9700 (RDNA4, `gfx1201`) and
+AMD's Windows ROCm/PyTorch wheels. It provides an OpenAI-compatible server,
+offline benchmarks, FP8/MXFP4 support where vLLM has a compatible kernel, and a
+fail-closed VRAM watchdog for desktop GPUs.
 
----
+> **Thank you to AMD** for the Threadripper platform and Radeon AI PRO R9700
+> hardware that made this native-Windows ROCm work possible.
 
-## About
+<!-- Separate the acknowledgement and warning callouts. -->
 
-vLLM is a fast and easy-to-use library for LLM inference and serving.
+> [!WARNING]
+> This is not an official AMD or vLLM release. The tested stack is version
+> pinned, single-GPU only, and still experimental. Read
+> [VRAM safety](#vram-safety) before loading a model.
 
-Originally developed in the [Sky Computing Lab](https://sky.cs.berkeley.edu) at UC Berkeley, vLLM has grown into one of the most active open-source AI projects built and maintained by a diverse community of many dozens of academic institutions and companies from over 2000 contributors.
+## Project status
 
-vLLM is fast with:
+| Item | Current status |
+| --- | --- |
+| Host OS | Native Windows 11 x64 |
+| Tested GPU | AMD Radeon AI PRO R9700, RDNA4 `gfx1201`, 32 GiB |
+| vLLM base | v0.26.0, base commit `568afb3` |
+| Python | 3.12.10 |
+| PyTorch | 2.11.0 + ROCm 7.13.0 |
+| ROCm SDK | 7.13.0 Python wheels, including development tools |
+| Triton | `triton-windows` 3.6.0.post26 |
+| Serving | OpenAI-compatible HTTP API |
+| Parallelism | One process, one GPU; no tensor/pipeline multi-GPU |
+| Model files | Hugging Face/Safetensors formats; no GGUF plugin included |
+| Vulkan | Not used by this vLLM backend |
 
-- State-of-the-art serving throughput
-- Efficient management of attention key and value memory with [**PagedAttention**](https://blog.vllm.ai/2023/06/20/vllm.html)
-- Continuous batching of incoming requests, chunked prefill, prefix caching
-- Fast and flexible model execution with piecewise and full CUDA/HIP graphs
-- Quantization: FP8, MXFP8/MXFP4, NVFP4, INT8, INT4, GPTQ/AWQ, GGUF, compressed-tensors, ModelOpt, TorchAO, and [more](https://docs.vllm.ai/en/latest/features/quantization/index.html)
-- Optimized attention kernels including FlashAttention, FlashInfer, TRTLLM-GEN, FlashMLA, and Triton
-- Optimized GEMM/MoE kernels for various precisions using CUTLASS, TRTLLM-GEN, CuTeDSL
-- Speculative decoding including n-gram, suffix, EAGLE, DFlash
-- Automatic kernel generation and graph-level transformations using torch.compile
-- Disaggregated prefill, decode, and encode
+Other AMD architectures may work after selecting matching ROCm wheels and
+changing the build target, but they are not validated by this repository yet.
+The checked-in build environment currently targets `gfx1201` explicitly.
 
-vLLM is flexible and easy to use with:
+## Why this Windows port is different
 
-- Seamless integration with popular Hugging Face models
-- High-throughput serving with various decoding algorithms, including *parallel sampling*, *beam search*, and more
-- Tensor, pipeline, data, expert, and context parallelism for distributed inference
-- Streaming outputs
-- Generation of structured outputs using xgrammar or guidance
-- Tool calling and reasoning parsers
-- OpenAI-compatible API server, plus Anthropic Messages API and gRPC support
-- Efficient multi-LoRA support for dense and MoE layers
-- Support for NVIDIA GPUs, AMD GPUs, and x86/ARM/PowerPC CPUs. Additionally, diverse hardware plugins such as Google TPUs, Intel Gaudi, IBM Spyre, Huawei Ascend, Rebellions NPU, Apple Silicon, MetaX GPU, and more.
+Upstream vLLM supports AMD ROCm, but its official GPU requirements list Linux
+and explicitly state that vLLM does not support Windows natively. This fork
+keeps vLLM's ROCm/HIP execution path and native extensions instead of replacing
+the engine with llama.cpp, ONNX Runtime, DirectML, or a Vulkan backend.
 
-vLLM seamlessly supports 200+ model architectures on Hugging Face, including:
+The comparison below was checked on 2026-08-09. These projects continue to
+evolve, so follow the links for their latest status.
 
-- Decoder-only LLMs (e.g., Llama, Qwen, Gemma)
-- Mixture-of-Expert LLMs (e.g., Mixtral, DeepSeek-V3, Qwen-MoE, GPT-OSS)
-- Hybrid attention and state-space models (e.g., Mamba, Qwen3.5)
-- Multi-modal models (e.g., LLaVA, Qwen-VL, Pixtral)
-- Embedding and retrieval models (e.g., E5-Mistral, GTE, ColBERT)
-- Reward and classification models (e.g., Qwen-Math)
+| Project | OS and accelerator | Architectural difference |
+| --- | --- | --- |
+| [Upstream vLLM](https://docs.vllm.ai/en/latest/getting_started/installation/gpu.html) | Official GPU requirements list Linux; no native Windows support | This is the source project. This fork adds native-Windows build and runtime compatibility while retaining its ROCm platform. |
+| [SystemPanic/vllm-windows](https://github.com/SystemPanic/vllm-windows) | Native Windows, NVIDIA CUDA | A Windows port centered on CUDA, CUDA libraries, and optional Windows NCCL. It is not an AMD ROCm port. |
+| [lemonade-sdk/vllm-rocm](https://github.com/lemonade-sdk/vllm-rocm) | AMD ROCm portable bundles for Linux/Lemonade | Ships a relocatable Linux runtime and explicitly requires a Linux kernel with `amdgpu`; it does not build this in-tree native-Windows fork. |
+| [ThePie88/vLLM-ROCm-Windows](https://github.com/ThePie88/vLLM-ROCm-Windows) | Native Windows, AMD ROCm, primarily tested on RDNA3 `gfx1100` | An out-of-tree vLLM platform plugin and compatibility layer. It installs upstream vLLM without its normal kernel build, then separately loads selected native/custom kernels. |
+| This repository | Native Windows, AMD ROCm, tested on RDNA4 `gfx1201` | An in-tree vLLM fork that builds vLLM's HIP extensions directly, patches Windows process/runtime assumptions, and ships safe AMD-tuned launchers plus a VRAM/stall watchdog. |
 
-Find the full list of supported models [here](https://docs.vllm.ai/en/latest/models/supported_models.html).
+This project is therefore not the only native-Windows AMD experiment. Its
+distinctive scope is an integrated, RDNA4-tested, in-tree vLLM ROCm build with
+operational safety tooling.
 
-## Getting Started
+## How it works
 
-Install vLLM with [`uv`](https://docs.astral.sh/uv/) (recommended) or `pip`:
+```text
+OpenAI client / benchmark
+          |
+          v
+vLLM V1 scheduler, PagedAttention, continuous batching, prefix cache
+          |
+          +--> Windows process, TCP/ZMQ and event-loop compatibility
+          +--> single-rank c10d stand-in (fails if real peers are requested)
+          +--> torch.compile / Inductor / Triton
+          |
+          v
+PyTorch ROCm -> HIP / hipBLASLt -> AMD Radeon GPU
 
-```bash
-uv pip install vllm
+Windows GPU performance counters ---> vram_guard.ps1 ---> launched tree only
+run-specific log timestamps --------> stall detector -----^
 ```
 
-Or [build from source](https://docs.vllm.ai/en/latest/getting_started/installation/gpu/index.html#build-wheel-from-source) for development.
+The important porting work includes:
 
-Visit our [documentation](https://docs.vllm.ai/en/latest/) to learn more.
+- Building vLLM's C++/HIP extensions with `clang-cl`, MSVC, CMake, and the ROCm
+  SDK delivered inside AMD's Python wheels.
+- Normalizing Windows paths before CMake interprets them and providing MSVC
+  equivalents for POSIX-only source APIs.
+- Detecting ROCm devices through `torch.cuda` when `amdsmi` is unavailable on
+  Windows.
+- Installing a single-rank `torch.distributed` stand-in because the tested AMD
+  Windows PyTorch wheel has no c10d extension. Operations requiring another
+  rank fail instead of silently returning incorrect results.
+- Replacing Unix IPC assumptions with loopback TCP/ZMQ and handling Windows
+  multiprocessing handles correctly.
+- Selecting `winloop` or standard `asyncio` when POSIX-only `uvloop` is absent.
+- Preferring hipBLASLt on RDNA4. On the test card, the untuned rocBLAS path was
+  dramatically slower for BF16/FP16 GEMMs.
+- Keeping Inductor and Triton caches in short paths to avoid Windows `MAX_PATH`
+  failures.
+- Monitoring total dedicated VRAM and log progress independently of vLLM, then
+  terminating only the process tree launched by the watchdog.
 
-- [Installation](https://docs.vllm.ai/en/latest/getting_started/installation.html)
-- [Quickstart](https://docs.vllm.ai/en/latest/getting_started/quickstart.html)
-- [List of Supported Models](https://docs.vllm.ai/en/latest/models/supported_models.html)
+See [WINDOWS_ROCM_PERFORMANCE.md](WINDOWS_ROCM_PERFORMANCE.md) for measured
+results, profiles, and current kernel limitations.
 
-## Contributing
+## Requirements
 
-We welcome and value any contributions and collaborations.
-Please check out [Contributing to vLLM](https://docs.vllm.ai/en/latest/contributing/index.html) for how to get involved.
+### Hardware and operating system
 
-## Citation
+- Windows 11 x64.
+- An AMD GPU supported by the Windows ROCm/PyTorch release you install. Check
+  AMD's current [Windows compatibility matrix](https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/compatibility/compatibilityrad/windows/windows_compatibility.html)
+  and [HIP SDK system requirements](https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/shared/hipsdk/reference/system-requirements.html).
+- This branch is tested only on `gfx1201`: Radeon AI PRO R9700 and the same
+  RDNA4 target family.
+- Enough system RAM and disk for the checkpoint plus build intermediates.
+  Thirty-two GiB of system RAM is a practical floor for smaller models; 64 GiB
+  or more is recommended for larger checkpoints and source builds.
 
-If you use vLLM for your research, please cite our [paper](https://arxiv.org/abs/2309.06180):
+### Software
+
+| Component | Tested version | Why it is needed |
+| --- | --- | --- |
+| AMD Radeon Software driver | A version matched to the selected ROCm release | Provides the Windows display/compute driver and HIP device access. |
+| Python | 3.12 x64 | Matches the tested AMD PyTorch wheels. |
+| Git | Current Windows release | Clones and updates the source tree. |
+| [uv](https://docs.astral.sh/uv/) | Current release | Creates the isolated environment and installs Python packages. |
+| Visual Studio 2022 Build Tools | MSVC v143, Desktop development with C++, Windows SDK | Supplies the Windows compiler, linker, headers, and libraries. The current script expects the standard Build Tools installation path. |
+| CMake | 4.4.2 | Required for the tested `clang-cl` HIP configuration. CMake 3.31 failed during configuration. |
+| Ninja | 1.13 | Drives the native extension build. |
+| ROCm SDK development wheels | 7.13.0 | Supply HIP, Clang, device libraries, headers, and math libraries inside the Python environment. |
+| PyTorch ROCm wheel | 2.11.0 + ROCm 7.13.0 | Tensor runtime and AMD GPU integration. |
+| `triton-windows` | 3.6.0.post26 | Compiles vLLM's Triton kernels on native Windows. |
+
+AMD notes that the complete Linux ROCm stack is not present on Windows. This
+project uses the Windows-supported HIP/ROCm components packaged with AMD's
+PyTorch and ROCm SDK wheels. AMD's [TheRock releases](https://github.com/ROCm/TheRock/blob/main/RELEASES.md)
+document the current Windows packages and GPU-specific `device-*` targets.
+The tested Torch 2.11/ROCm 7.13 packages are newer than AMD's current stable
+Windows support matrix and should be treated as a pinned preview stack.
+
+### Do I need Vulkan?
+
+No. This repository uses ROCm/HIP, not Vulkan. Installing the Vulkan SDK will
+not enable or accelerate vLLM here.
+
+The AMD display driver normally supplies the Vulkan runtime for applications
+that use it. Install the Vulkan SDK only if you are developing or compiling a
+separate Vulkan application, such as a Vulkan-enabled llama.cpp build. Do not
+install Vulkan as a substitute for the ROCm/PyTorch stack above.
+
+## Installation
+
+The commands below reproduce the stack tested in this repository. Package
+indexes change over time; do not mix arbitrary Torch, ROCm, Triton, and vLLM
+versions and expect ABI compatibility.
+
+### 1. Install the system tools
+
+Install:
+
+- A compatible AMD Radeon Software driver.
+- Python 3.12 x64.
+- Git for Windows.
+- Visual Studio 2022 Build Tools with **Desktop development with C++**, MSVC
+  v143, and a Windows 10 or 11 SDK.
+- `uv` from its [official installation guide](https://docs.astral.sh/uv/getting-started/installation/).
+
+Reboot after installing or changing the AMD driver.
+
+### 2. Clone into a short path
+
+PowerShell:
+
+```powershell
+New-Item -ItemType Directory -Path C:\AI -Force | Out-Null
+git clone https://github.com/charlie12345/vLLM_for_AMD.git C:\AI\vllm
+Set-Location C:\AI\vllm
+```
+
+A short path matters when Torch/Inductor generates deeply nested cache names.
+
+### 3. Create the serving environment
+
+```powershell
+uv venv --python 3.12 .venv211
+
+uv pip install --python .\.venv211\Scripts\python.exe `
+  --extra-index-url https://repo.amd.com/rocm/whl/gfx120X-all/ `
+  --index-strategy unsafe-best-match `
+  "torch==2.11.0+rocm7.13.0" `
+  "torchvision==0.26.0+rocm7.13.0" `
+  "rocm[devel]==7.13.0"
+
+uv pip install --python .\.venv211\Scripts\python.exe `
+  "triton-windows==3.6.0.post26" winloop
+
+uv pip install --python .\.venv211\Scripts\python.exe `
+  -r .\requirements\common.txt
+
+uv pip install --python .\.venv211\Scripts\python.exe `
+  "cmake==4.4.2" ninja "packaging>=24.2" `
+  "setuptools>=77,<80" "setuptools-scm>=8" `
+  "setuptools-rust>=1.9" wheel "jinja2>=3.1.6"
+```
+
+Do **not** install `requirements/rocm.txt` wholesale on Windows. It contains
+Linux-only or unsupported packages such as TileLang, RunAI model streaming,
+FastSafetensors, AMD Quark, and other optional integrations. The commands above
+install the tested core serving stack while preserving AMD's ROCm Torch wheel.
+
+### 4. Verify ROCm before building vLLM
+
+```powershell
+.\.venv211\Scripts\python.exe -m rocm_sdk test
+
+.\.venv211\Scripts\python.exe -c `
+  "import torch; print(torch.__version__); print(torch.version.hip); print(torch.cuda.get_device_name(0)); print(torch.cuda.get_device_properties(0).gcnArchName)"
+```
+
+For the tested card, the final line must report `gfx1201`. Stop here if Torch
+cannot see the expected AMD GPU.
+
+### 5. Build and install this fork
+
+```powershell
+.\build_windows_rocm.cmd
+.\install_windows_rocm.cmd
+```
+
+These scripts load the Visual Studio environment, find ROCm through
+`python -m rocm_sdk path --root`, select `clang-cl` for both C++ and HIP, build
+for `gfx1201`, and install vLLM into `.venv211` in editable mode.
+
+Verify the install without loading a model:
+
+```powershell
+.\.venv211\Scripts\python.exe -c "import vllm; print(vllm.__version__)"
+```
+
+## Choosing and downloading a model
+
+Use a Hugging Face model architecture supported by
+[upstream vLLM](https://docs.vllm.ai/en/latest/models/supported_models.html), in
+Safetensors or another native vLLM format. A model being popular does not mean
+its particular quantization has a fast AMD RDNA4 kernel.
+
+### Models tested on this branch
+
+| Model | Format | Purpose and notes |
+| --- | --- | --- |
+| [`Qwen/Qwen3-0.6B`](https://huggingface.co/Qwen/Qwen3-0.6B) | BF16 or locally converted FP8 | Small smoke-test model. |
+| [`Qwen/Qwen3-8B`](https://huggingface.co/Qwen/Qwen3-8B) | BF16; locally tested with compressed-tensors FP8 | Good general baseline. Disable graph replay for the tested FP8-weight checkpoint. |
+| [`openai/gpt-oss-20b`](https://huggingface.co/openai/gpt-oss-20b) | Official MXFP4 Safetensors | Recommended larger native model. It loaded through built-in `GptOssForCausalLM`/`gpt_oss_mxfp4`, used 14.16 GiB for model memory, and needed no GGUF plugin or remote code. |
+
+Download a small public model:
+
+```powershell
+New-Item -ItemType Directory -Path C:\AI\models -Force | Out-Null
+.\.venv211\Scripts\hf.exe download Qwen/Qwen3-0.6B `
+  --local-dir C:\AI\models\Qwen3-0.6B
+```
+
+Download the tested larger model without its duplicate reference directories:
+
+```powershell
+.\.venv211\Scripts\hf.exe download openai/gpt-oss-20b `
+  --local-dir C:\AI\models\gpt-oss-20b `
+  --exclude "original/*" "metal/*"
+```
+
+For a gated model, authenticate interactively instead of placing a Hugging
+Face token in a script or command line:
+
+```powershell
+.\.venv211\Scripts\hf.exe auth login
+```
+
+The token is stored in the user's Hugging Face cache, outside this repository.
+See the official [Hugging Face authentication documentation](https://huggingface.co/docs/huggingface_hub/package_reference/authentication).
+
+### Model-format guidance
+
+| Format | RDNA4 status in this fork |
+| --- | --- |
+| BF16/FP16 Safetensors | Supported when the weights plus runtime/KV memory fit. BF16 is the safer default. |
+| GPT-OSS MXFP4 | Supported through vLLM's built-in Triton MXFP4 MoE path. |
+| FP8 compressed-tensors | Supported, but graph replay can hang on some larger FP8 shapes; start with `cudagraph_mode=NONE`. |
+| FP8 KV cache | Supported and roughly halves KV memory. Validate output quality because untuned default scales can affect accuracy. |
+| AWQ/GPTQ INT4 | Do not assume a fast or working `gfx1201` kernel. This remains kernel-dependent. |
+| GGUF | Not included in core vLLM here. The official GGUF path is an out-of-tree plugin, which this project does not install. Prefer native Safetensors checkpoints. |
+| `trust_remote_code` models | Potentially supported, but review the repository code first. Never enable the flag for an untrusted model. |
+
+As a conservative rule on a display-connected GPU, keep several GiB free for
+Windows and temporary activations. Checkpoint file size is not the same as peak
+VRAM use. Model weights, KV cache, activations, compiler workspaces, and the
+desktop all share the card.
+
+## Quick start: guarded OpenAI-compatible server
+
+The launchers default to `--gpu-memory-utilization 0.55`. The watchdog adds an
+independent absolute VRAM ceiling.
+
+Open PowerShell in the repository and run:
+
+```powershell
+$root = 'C:\AI\vllm'
+$model = 'C:\AI\models\gpt-oss-20b'
+$logs = Join-Path $root 'logs'
+New-Item -ItemType Directory -Path $logs -Force | Out-Null
+
+$serverLog = Join-Path $logs 'gpt-oss-server.log'
+$guardLog = Join-Path $logs 'gpt-oss-server.guard.log'
+$command = "`"$root\serve_windows_rocm.cmd`" `"$model`" " +
+  "--served-model-name gpt-oss-20b --host 127.0.0.1 --port 8000 " +
+  "--max-model-len 2048 --gpu-memory-utilization 0.55 " +
+  "-cc.cudagraph_mode=NONE > `"$serverLog`" 2>&1"
+
+& "$root\vram_guard.ps1" `
+  -Command $command `
+  -LimitGiB 26 `
+  -WarnGiB 23 `
+  -LogPath $guardLog
+```
+
+For a long-lived server, the example intentionally omits `-StallLogPath`: an
+idle API server can legitimately produce no log output. The absolute VRAM
+limit remains active. Use stall detection for finite benchmarks and conversion
+jobs.
+
+The guard prints the exact child PID. To stop the server, terminate that exact
+tree from another terminal rather than killing every Python process on the
+machine:
+
+```powershell
+$childPid = Read-Host "Enter the child PID printed by vram_guard.ps1"
+taskkill /PID $childPid /T /F
+```
+
+Do not close or interrupt the guard and leave its child running. After a forced
+stop, verify any remaining process by command line before terminating it.
+
+### Send a chat request
+
+Run this in a second PowerShell window:
+
+```powershell
+$body = @{
+  model = 'gpt-oss-20b'
+  messages = @(
+    @{ role = 'user'; content = 'Explain PagedAttention in two sentences.' }
+  )
+  max_tokens = 128
+  temperature = 0
+} | ConvertTo-Json -Depth 5
+
+Invoke-RestMethod `
+  -Uri http://127.0.0.1:8000/v1/chat/completions `
+  -Method Post `
+  -ContentType 'application/json' `
+  -Body $body
+```
+
+## Benchmarking
+
+Every model benchmark should use a fresh log and the watchdog:
+
+```powershell
+$stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$log = "C:\AI\vllm\logs\qwen-smoke-$stamp.log"
+$guardLog = "C:\AI\vllm\logs\qwen-smoke-$stamp.guard.log"
+$command = "C:\AI\vllm\bench_windows_rocm.cmd throughput " +
+  "--model C:\AI\models\Qwen3-0.6B --tokenizer C:\AI\models\Qwen3-0.6B " +
+  "--dataset-name random --num-prompts 8 " +
+  "--random-input-len 256 --random-output-len 64 " +
+  "--max-model-len 2048 --gpu-memory-utilization 0.55 " +
+  "> `"$log`" 2>&1"
+
+.\vram_guard.ps1 `
+  -Command $command `
+  -LimitGiB 26 `
+  -WarnGiB 23 `
+  -StallLogPath $log `
+  -StallSec 300 `
+  -LogPath $guardLog
+```
+
+The first run for a new model/batch shape may include Triton and Inductor JIT
+compilation. Repeat the identical workload before calling a result steady
+state.
+
+## VRAM safety
+
+`--gpu-memory-utilization` and `vram_guard.ps1` solve different problems:
+
+- The launcher setting tells vLLM how much GPU memory it may plan to use for
+  weights, activations, graphs, and KV cache. The wrappers inject `0.55` unless
+  the command already specifies a value.
+- The watchdog reads Windows' dedicated-GPU-memory performance counter. It sees
+  total adapter usage, including the desktop and other applications, and can
+  terminate only the process tree it launched.
+
+The watchdog fails closed:
+
+- Exit `98`: Windows GPU memory counters were unavailable, so the command was
+  not launched.
+- Exit `99`: the process tree crossed the VRAM limit, stopped producing log
+  output for the configured interval, or the counter repeatedly failed.
+- Any other exit code is the launched command's exit code.
+
+### Changing the limits for another GPU
+
+You normally do not need to edit `vram_guard.ps1`. Pass limits per run:
+
+```powershell
+.\vram_guard.ps1 `
+  -Command $command `
+  -LimitGiB 40 `
+  -WarnGiB 36 `
+  -StallLogPath $log `
+  -StallSec 420 `
+  -LogPath $guardLog
+```
+
+Choose values from measurements, not only the advertised card capacity:
+
+1. Measure the idle Windows desktop VRAM use.
+2. Reserve at least 4-6 GiB on a display-connected card; reserve more if other
+   GPU applications remain open.
+3. Set `LimitGiB` to the highest **total dedicated usage** you will tolerate.
+4. Set `WarnGiB` 2-4 GiB below that limit.
+5. Start vLLM at `--gpu-memory-utilization 0.55`, confirm peak usage, then move
+   upward in small steps. More KV cache is not automatically faster.
+
+For example, `26/23 GiB` is measured and conservative on the 32 GiB R9700 that
+also drives the desktop. A headless compute card or a card with more VRAM may
+use a higher absolute limit, but still needs workspace and OS headroom.
+
+Change the launcher's default without editing it:
+
+```powershell
+$env:WINDOWS_ROCM_GPU_MEMORY_UTILIZATION = '0.65'
+$env:WINDOWS_ROCM_KV_CACHE_DTYPE = 'fp8'
+$env:WINDOWS_ROCM_CUDAGRAPH_MODE = 'NONE'
+```
+
+Explicit command-line flags take precedence over these variables.
+
+> [!CAUTION]
+> `vram_guard.ps1` monitors dedicated GPU memory, not system RAM. Windows may
+> spill GPU allocations into shared system memory before an ordinary CUDA/HIP
+> free-memory query looks obviously wrong. Keep real dedicated-VRAM headroom.
+
+## Useful flags
+
+| Flag | Recommended starting point | Effect |
+| --- | --- | --- |
+| `--gpu-memory-utilization` | `0.55` | vLLM's planned fraction of GPU memory. Raise only after guarded measurements. |
+| `--max-model-len` | `2048` for the first test | Caps context length and makes initial memory requirements predictable. |
+| `--kv-cache-dtype` | `auto`/BF16 first; test `fp8` later | FP8 roughly halves KV memory, but quality should be evaluated. |
+| `-cc.cudagraph_mode=NONE` | Use for known-problem FP8 checkpoints | Keeps Torch/Inductor compilation but disables HIP graph capture/replay. |
+| `--attention-backend` | Leave on `auto` | Allows the ROCm platform to choose. `TRITON_ATTN` is useful for an explicit A/B test. |
+| `--max-num-seqs` | Leave at the vLLM default initially | Limits concurrent sequences. The default beat manually reduced values in the measured Qwen workload. |
+| `--max-num-batched-tokens` | Leave at the vLLM default initially | Controls scheduler token capacity; tune with a representative workload. |
+| `--served-model-name` | A short stable API name | Avoids requiring clients to send an absolute Windows model path. |
+| `--host` | `127.0.0.1` | Keeps the server local. Binding `0.0.0.0` exposes it to the network. |
+| `--trust-remote-code` | Off | Executes Python from the model repository. Enable only after reviewing trusted code. |
+
+On a machine with multiple GPUs, select one before starting vLLM:
+
+```powershell
+$env:HIP_VISIBLE_DEVICES = '0'
+```
+
+This does not enable multi-GPU vLLM; it selects the one visible GPU used by the
+single-rank runtime.
+
+## Measured results
+
+Radeon AI PRO R9700, Windows 11, maximum model length 2,048:
+
+| Model and workload | Configuration | Output throughput | Peak dedicated VRAM |
+| --- | --- | ---: | ---: |
+| Qwen3-8B FP8, 64 × 1,024 input / 128 output | FP8 KV, util 0.55, no graphs | 614.88 tok/s | 20.79 GiB |
+| Qwen3-8B BF16, 64 × 1,024 input / 128 output | FP8 KV, util 0.67 | 459.42-464.02 tok/s | 24.79-24.97 GiB |
+| GPT-OSS-20B, 1 × 256 input / 64 output | BF16 KV, util 0.55, no graphs | 32.80 tok/s | 21.25 GiB |
+| GPT-OSS-20B, 8 × 256 input / 64 output | BF16 KV, util 0.55, no graphs | 209.62 tok/s | 21.20 GiB |
+
+These are throughput checks, not model-quality evaluations. See
+[WINDOWS_ROCM_PERFORMANCE.md](WINDOWS_ROCM_PERFORMANCE.md) for methodology and
+known caveats.
+
+## Security and credentials
+
+Do not commit API keys, Hugging Face tokens, model-provider credentials, TLS
+private keys, `.env` files, logs, profiles, or downloaded model weights.
+
+This repository's `.gitignore` excludes common local secret files and generated
+run artifacts, but ignore rules are not a security boundary. In particular,
+`vram_guard.ps1` records the launched command, so never put a real token in
+`--api-key` or another command-line flag.
+
+If the API must require a key, read it interactively into an environment
+variable before launching the guard:
+
+```powershell
+$secure = Read-Host 'Local vLLM API key' -AsSecureString
+$env:VLLM_API_KEY = [System.Net.NetworkCredential]::new('', $secure).Password
+Remove-Variable secure
+```
+
+The child process inherits the variable without the value appearing in the
+guard's logged command. Keep `--host 127.0.0.1` unless you have intentionally
+configured authentication, Windows Firewall, and network access controls.
+
+Before every commit and push:
+
+```powershell
+git status --short
+git diff --cached
+git grep -n -I -E "(hf_|ghp_|github_pat_|AKIA|BEGIN .*PRIVATE KEY|sk-)" -- .
+```
+
+Review every match; some source identifiers can be false positives. Enable
+[GitHub secret scanning and push protection](https://docs.github.com/en/code-security/concepts/secret-security/push-protection)
+on the repository as a second layer. If a real credential is ever committed,
+rotate or revoke it immediately; deleting the working-tree file does not remove
+it from Git history.
+
+## Building for a different AMD architecture
+
+The current `env_windows_rocm.cmd` contains two explicit `gfx1201` settings:
+
+- `PYTORCH_ROCM_ARCH=gfx1201`
+- `-DCMAKE_HIP_ARCHITECTURES=gfx1201`
+
+To experiment with another GPU:
+
+1. Find its GFX target in AMD's support matrix or with a working ROCm Torch
+   install.
+2. Install the matching AMD ROCm/PyTorch device wheels. Do not use `gfx120X-all`
+   for an unrelated architecture.
+3. Change both build targets above to the same GFX value.
+4. Delete only the repository's generated build directory, rebuild, and start
+   with a very small model under conservative guard limits.
+
+Architecture support in a ROCm wheel does not guarantee that every vLLM
+attention or quantization kernel supports that architecture. Treat all targets
+other than `gfx1201` as unverified until they pass model-load, coherent-output,
+VRAM, and throughput tests.
+
+## Known limitations and troubleshooting
+
+- **Single GPU only:** Windows ROCm Torch lacks the tested c10d/RCCL stack. The
+  compatibility layer supports rank 0/world size 1 and rejects real peer work.
+- **Expected `amdsmi` warning:** Windows has no compatible `amdsmi` package in
+  this stack. The port falls back to Torch for device detection and properties.
+- **CMake must be new enough:** the tested HIP + `clang-cl` configuration needs
+  CMake 4.4.2. Upstream's ROCm build requirements currently constrain CMake
+  below 4, so do not install that requirements file unchanged.
+- **Short cache paths matter:** the launchers default to `C:\AI\vc` and
+  `C:\AI\vt`. Override them with `VLLM_CACHE_ROOT` and `TRITON_CACHE_DIR`, but
+  keep them short unless Windows long-path support is enabled.
+- **FP8-weight graph replay:** a tested Qwen3-8B FP8 checkpoint can wedge during
+  HIP graph replay. Use `-cc.cudagraph_mode=NONE`; the watchdog catches the
+  silent stall.
+- **Cold-start compilation:** new models and batch shapes can trigger Triton or
+  Inductor compilation. Measure the repeated run.
+- **`run-batch` frontend:** native Windows may require
+  `WindowsSelectorEventLoopPolicy` for pyzmq, and current cleanup contains a
+  Unix-only `SIGKILL` call. Output can be valid even if shutdown returns status
+  1. The throughput runner exits cleanly.
+- **Vulkan is not a fallback:** if ROCm fails, installing Vulkan does not repair
+  this vLLM backend.
+- **INT4 is kernel-dependent:** AWQ/GPTQ model size alone is not proof that its
+  CUDA-oriented kernel has a correct, fast RDNA4 path.
+
+## Repository scripts
+
+| File | Purpose |
+| --- | --- |
+| `env_windows_rocm.cmd` | Shared Visual Studio, ROCm, compiler, and architecture environment. |
+| `build_windows_rocm.cmd` | Builds vLLM's C++/HIP extensions in place. |
+| `install_windows_rocm.cmd` | Installs this source tree into `.venv211` without replacing ROCm Torch. |
+| `serve_windows_rocm.cmd` | Runs `vllm serve` with Windows/AMD settings and safe configurable defaults. |
+| `bench_windows_rocm.cmd` | Runs `vllm bench` in the same environment used for serving. |
+| `vram_guard.ps1` | Fail-closed dedicated-VRAM and optional stall watchdog. |
+| `quantize_fp8.py` | Optional CPU-side FP8 conversion helper; use a separate quantization environment. |
+| `WINDOWS_ROCM_PERFORMANCE.md` | Reproducible measurements, profiles, and blockers. |
+
+## Updating from upstream
+
+This is a focused patch stack on top of vLLM, not an independent inference
+engine. Upstream changes can alter Python APIs, kernels, dependencies, and build
+requirements. Rebase onto a known vLLM tag, review every Windows patch, rebuild
+the native extensions, and rerun guarded model/quality benchmarks before
+publishing an update.
+
+Contributors must also follow [AGENTS.md](AGENTS.md) and upstream's
+[contribution guide](CONTRIBUTING.md). AI-assisted changes require human review,
+appropriate tests, and disclosure under the repository's contribution policy.
+
+## License and attribution
+
+This repository is based on
+[vllm-project/vllm](https://github.com/vllm-project/vllm) and retains its
+[Apache License 2.0](LICENSE). See [NOTICE](NOTICE) for the upstream base and
+modification attribution.
+
+ROCm, PyTorch, Triton, Hugging Face models, and other downloaded dependencies
+are separate projects with their own licenses and notices. They are not
+relicensed by this repository. Review a model's license before downloading,
+redistributing, or serving it.
+
+If you use vLLM in research, cite the original project:
 
 ```bibtex
 @inproceedings{kwon2023efficient,
   title={Efficient Memory Management for Large Language Model Serving with PagedAttention},
-  author={Woosuk Kwon and Zhuohan Li and Siyuan Zhuang and Ying Sheng and Lianmin Zheng and Cody Hao Yu and Joseph E. Gonzalez and Hao Zhang and Ion Stoica},
+  author={Kwon, Woosuk and Li, Zhuohan and Zhuang, Siyuan and Sheng, Ying and Zheng, Lianmin and Yu, Cody Hao and Gonzalez, Joseph E. and Zhang, Hao and Stoica, Ion},
   booktitle={Proceedings of the ACM SIGOPS 29th Symposium on Operating Systems Principles},
   year={2023}
 }
 ```
 
-## Contact Us
-
-<!-- --8<-- [start:contact-us] -->
-- For technical questions and feature requests, please use GitHub [Issues](https://github.com/vllm-project/vllm/issues)
-- For discussing with fellow users, please use the [vLLM Forum](https://discuss.vllm.ai)
-- For coordinating contributions and development, please use [Slack](https://slack.vllm.ai)
-- For security disclosures, please use GitHub's [Security Advisories](https://github.com/vllm-project/vllm/security/advisories) feature
-- For collaborations and partnerships, please contact us at [collaboration@vllm.ai](mailto:collaboration@vllm.ai)
-<!-- --8<-- [end:contact-us] -->
-
-## Media Kit
-
-- If you wish to use vLLM's logo, please refer to [our media kit repo](https://github.com/vllm-project/media-kit)
+Upstream documentation: <https://docs.vllm.ai/>

--- a/WINDOWS_ROCM_PERFORMANCE.md
+++ b/WINDOWS_ROCM_PERFORMANCE.md
@@ -1,9 +1,9 @@
 # Native Windows ROCm performance notes
 
-These results are for a Radeon AI PRO R9700 (gfx1201, 32 GiB), ROCm 7.1,
-PyTorch 2.11, and Qwen3 at a maximum model length of 2,048. The GPU also drives
-the desktop. Every model run below used `vram_guard.ps1` with a 26 GiB hard
-limit and a per-run stall log.
+These results are for a Radeon AI PRO R9700 (gfx1201, 32 GiB), ROCm 7.13.0,
+PyTorch 2.11, and models at a maximum model length of 2,048. The GPU also
+drives the desktop. Every model run below used `vram_guard.ps1` with a 26 GiB
+hard limit and a per-run stall log.
 
 ## Recommended configurations
 
@@ -37,6 +37,36 @@ peaked at 24.11 GiB.
 FP8 KV cache can affect output quality when the model does not provide tuned
 KV scales. These are throughput results, not an accuracy evaluation. Run the
 model's task evaluation before making FP8 KV the production default.
+
+### Larger model without a GGUF plugin
+
+`openai/gpt-oss-20b` works from its official Safetensors checkpoint through
+vLLM's built-in `GptOssForCausalLM` and `gpt_oss_mxfp4` paths. It does not use
+GGUF, a GGUF plugin, or remote model code. The local checkpoint is in
+`C:\AI\models\gpt-oss-20b`.
+
+The stable baseline is:
+
+```text
+--gpu-memory-utilization 0.55
+--max-model-len 2048
+-cc.cudagraph_mode=NONE
+```
+
+vLLM loaded 12.82 GiB of checkpoint shards into 14.16 GiB of GPU model memory,
+selected `OAITritonMxfp4ExpertsMonolithic`, and allocated 51,741 BF16 KV-cache
+tokens. A single request with 256 input and 64 output tokens produced 32.80
+output tokens/s. Eight concurrent requests of the same size produced 209.62
+output tokens/s and 1,048.08 total tokens/s. The two guarded runs peaked at
+21.25 and 21.20 GiB, respectively.
+
+An offline chat request also completed with HTTP 200, a normal `stop` finish,
+and the correct final response. The `run-batch` frontend needs
+`WindowsSelectorEventLoopPolicy` for pyzmq on native Windows. After output is
+written, its cleanup currently calls the Unix-only `signal.SIGKILL`, so that
+frontend exits with status 1 despite successful inference. The throughput
+runner exits cleanly; these are frontend compatibility issues, not a model or
+ROCm failure.
 
 ## Launcher settings
 

--- a/WINDOWS_ROCM_PERFORMANCE.md
+++ b/WINDOWS_ROCM_PERFORMANCE.md
@@ -1,0 +1,119 @@
+# Native Windows ROCm performance notes
+
+These results are for a Radeon AI PRO R9700 (gfx1201, 32 GiB), ROCm 7.1,
+PyTorch 2.11, and Qwen3 at a maximum model length of 2,048. The GPU also drives
+the desktop. Every model run below used `vram_guard.ps1` with a 26 GiB hard
+limit and a per-run stall log.
+
+## Recommended configurations
+
+For the local Qwen3-8B FP8 compressed-tensors checkpoint, the fastest stable
+configuration measured was:
+
+```text
+--gpu-memory-utilization 0.55
+--kv-cache-dtype fp8
+-cc.cudagraph_mode=NONE
+```
+
+It produced 614.88 output tokens/s for 64 random prompts with 1,024 input and
+128 output tokens, used 104,320 KV-cache tokens, and peaked at 20.79 GiB.
+Inductor compilation remains enabled; only HIP graph capture/replay is
+disabled.
+
+For BF16 Qwen3-8B, a throughput-oriented configuration is:
+
+```text
+--gpu-memory-utilization 0.67
+--kv-cache-dtype fp8
+```
+
+It produced 459.42 and 464.02 output tokens/s in repeated warm runs, held all
+64 requests in 74,816 KV-cache tokens, and peaked at 24.97 and 24.79 GiB. This
+is a benchmark setting with about 1 GiB of watchdog headroom. Use 0.65 for a
+more conservative desktop setting; it produced 358.01 output tokens/s and
+peaked at 24.11 GiB.
+
+FP8 KV cache can affect output quality when the model does not provide tuned
+KV scales. These are throughput results, not an accuracy evaluation. Run the
+model's task evaluation before making FP8 KV the production default.
+
+## Launcher settings
+
+`bench_windows_rocm.cmd` and `serve_windows_rocm.cmd` keep the conservative
+0.55 memory default. The following optional environment variables provide
+defaults when the corresponding CLI argument is absent:
+
+- `WINDOWS_ROCM_GPU_MEMORY_UTILIZATION`
+- `WINDOWS_ROCM_KV_CACHE_DTYPE`
+- `WINDOWS_ROCM_CUDAGRAPH_MODE`
+
+Explicit CLI arguments take precedence. For example, an FP8 serving session
+can be launched from PowerShell with:
+
+```powershell
+$env:WINDOWS_ROCM_KV_CACHE_DTYPE = 'fp8'
+$env:WINDOWS_ROCM_CUDAGRAPH_MODE = 'NONE'
+.\serve_windows_rocm.cmd C:\AI\models\Qwen3-8B-FP8-Dynamic --max-model-len 2048
+```
+
+Keep the server under the watchdog used in the handoff when it shares a GPU
+with the desktop.
+
+## Measurements
+
+All throughput rows use 64 prompts, 1,024 input tokens, 128 output tokens, and
+a maximum model length of 2,048.
+
+| Weights | KV dtype | Utilization | Scheduler/backend | Output tok/s | Peak GiB |
+| --- | --- | ---: | --- | ---: | ---: |
+| BF16 | BF16 | 0.55 | defaults/auto | 188.30 | 20.90 |
+| BF16 | BF16 | 0.60 | defaults/auto | 279.48 | 22.39 |
+| BF16 | BF16 | 0.65 | defaults/auto | 325.07 | 24.15 |
+| BF16 | BF16 | 0.70 | defaults/auto | 383.77 | 25.60 |
+| BF16 | FP8 | 0.55 | defaults/auto | 209.80 | 20.60 |
+| BF16 | FP8 | 0.65 | defaults/auto | 358.01 | 24.11 |
+| BF16 | FP8 | 0.67 | defaults/auto | 459.42, 464.02 | 24.97, 24.79 |
+| BF16 | FP8 | 0.68 | defaults/auto | 446.23 | 25.27 |
+| BF16 | FP8 | 0.67 | defaults/TRITON_ATTN, warm | 419.37 | 24.78 |
+| FP8 | BF16 | 0.55 | no graphs/auto | 527.06 | 21.63 |
+| FP8 | FP8 | 0.55 | no graphs/auto | 614.88 | 20.79 |
+| FP8 + 0.6B draft | FP8 | 0.55 | no graphs, draft K=3 | 63.48 | 20.79 |
+
+BF16 utilization values from 0.40 through 0.50 cannot allocate any KV cache
+after loading the 15.27 GiB checkpoint. The 0.55 run was not a batch-64 decode:
+it allocated 9,568 KV tokens and scheduled about eight requests at a time.
+A graph-mode profile measured 31.4 ms per decode step for that eight-request
+wave. The earlier estimate of roughly 240 ms per step incorrectly treated the
+eight sequential waves as one batch.
+
+An eager operator profile ranked GEMM above direct paged attention. Across 32
+profiled decode steps, `aten::mm` accumulated about 1.07 seconds while direct
+`_rocm_C::paged_attention` calls accumulated about 116 ms. Profiler overhead
+distorts those absolute eager times, but not enough to support attention as a
+10x bottleneck.
+
+The default scheduler settings (`max_num_seqs=256`,
+`max_num_batched_tokens=8192`) performed best. Setting `max_num_seqs=64`
+reduced KV residency and produced 354.72-386.87 output tokens/s across token
+budgets of 4,096-16,384. Explicit `TRITON_ATTN` was about 10% slower than the
+auto-selected `ROCM_ATTN` wrapper after both paths were warm.
+
+## Known blockers
+
+- FP8-weight graph replay still wedges after successful size-64 capture, with
+  either BF16 or FP8 KV cache. The watchdog reproduced and terminated the FP8
+  KV case after 241 seconds of silence at 20.88 GiB peak. Keep
+  `cudagraph_mode=NONE` for this checkpoint.
+- Qwen3-8B and Qwen3-0.6B do not contain native MTP heads. Generic draft-model
+  speculation disabled async scheduling and the V2 runner and was almost 10x
+  slower on the measured batch. N-gram speculation currently requires the
+  optional `numba` dependency, which is not installed in `.venv211`.
+- The current vLLM tree has no Vulkan platform or execution backend. The
+  Windows work in this branch accelerates the ROCm/HIP path. Vulkan performance
+  must be handled in a Vulkan-capable runtime rather than routed through these
+  vLLM launchers.
+
+Do not start tuned Triton configurations or new GEMM kernels until a workload
+that remains slow after correcting KV residency demonstrates that they are the
+dominant cost.

--- a/WINDOWS_ROCM_PERFORMANCE.md
+++ b/WINDOWS_ROCM_PERFORMANCE.md
@@ -68,6 +68,27 @@ frontend exits with status 1 despite successful inference. The throughput
 runner exits cleanly; these are frontend compatibility issues, not a model or
 ROCm failure.
 
+### Native AWQ INT4
+
+`Qwen/Qwen3-4B-AWQ` works from its official 2.48 GiB Safetensors checkpoint
+without a GGUF plugin. On gfx1201, compatible native AWQ layers are converted
+to the modular packed format and select `RDNAHybridW4A16LinearKernel`: HIP
+skinny W4A16 for decode batches up to five tokens and a gfx1201-tuned Triton
+W4A16 kernel for larger batches.
+
+With one random prompt, 64 input tokens, 16 output tokens, maximum model length
+512, `--gpu-memory-utilization 0.40`, and `cudagraph_mode=NONE`, the repeated
+run produced 65.80 output tokens/s and peaked at 16.35 GiB. The earlier generic
+AutoAWQ path produced 30.45 output tokens/s with the same workload. These
+single-request measurements are sensitive to first-shape Triton JIT; use a
+repeated run and a representative serving workload before drawing broader
+throughput conclusions. Deterministic offline generation produced coherent
+text through the hybrid path.
+
+The hybrid path is enabled by default for 4-bit AWQ group sizes 32, 64, and
+128 on gfx11/gfx12. Set `VLLM_ROCM_USE_RDNA_W4A16=0` to retain generic AutoAWQ
+for compatibility diagnosis.
+
 ## Launcher settings
 
 `bench_windows_rocm.cmd` and `serve_windows_rocm.cmd` keep the conservative

--- a/bench_windows_rocm.cmd
+++ b/bench_windows_rocm.cmd
@@ -1,0 +1,29 @@
+@echo off
+REM Run `vllm bench ...` on native Windows + ROCm. Same environment as serving,
+REM so the numbers reflect what the server actually does.
+REM Usage: bench_windows_rocm.cmd throughput --model <model> ...
+setlocal
+
+if "%VLLM_ROOT%"=="" set VLLM_ROOT=%~dp0
+set VENV=%VLLM_ROOT%.venv211
+
+set TORCH_BLAS_PREFER_HIPBLASLT=1
+set VLLM_WORKER_MULTIPROC_METHOD=spawn
+set VLLM_ATTENTION_BACKEND=TRITON_ATTN
+if "%VLLM_CACHE_ROOT%"=="" set VLLM_CACHE_ROOT=C:\AI\vc
+if "%TRITON_CACHE_DIR%"=="" set TRITON_CACHE_DIR=C:\AI\vt
+
+REM Safety: vLLM claims gpu-memory-utilization of the card and sizes the KV
+REM cache to fill whatever the weights leave over, so even a small model will
+REM allocate ~27 GiB by default. This card also drives the desktop, and RDNA4
+REM falls off a large-GEMM cliff under ~3 GiB free. Default to a conservative
+REM fraction unless the caller states one explicitly.
+echo %* | findstr /C:"gpu-memory-utilization" >nul
+if errorlevel 1 (
+  set VLLM_MEM_ARG=--gpu-memory-utilization 0.55
+) else (
+  set VLLM_MEM_ARG=
+)
+
+"%VENV%\Scripts\python.exe" -m vllm.entrypoints.cli.main bench %* %VLLM_MEM_ARG%
+exit /b %errorlevel%

--- a/bench_windows_rocm.cmd
+++ b/bench_windows_rocm.cmd
@@ -4,12 +4,16 @@ REM so the numbers reflect what the server actually does.
 REM Usage: bench_windows_rocm.cmd throughput --model <model> ...
 setlocal
 
-if "%VLLM_ROOT%"=="" set VLLM_ROOT=%~dp0
-set VENV=%VLLM_ROOT%.venv211
+set "ROCM_VLLM_ROOT=%~dp0"
+if not "%VLLM_ROOT%"=="" set "ROCM_VLLM_ROOT=%VLLM_ROOT%"
+set "VLLM_ROOT="
+set "VENV=%ROCM_VLLM_ROOT%.venv211"
 
 set TORCH_BLAS_PREFER_HIPBLASLT=1
 set VLLM_WORKER_MULTIPROC_METHOD=spawn
-set VLLM_ATTENTION_BACKEND=TRITON_ATTN
+REM VLLM_ATTENTION_BACKEND was removed upstream. The ROCm platform chooses
+REM ROCM_ATTN by default; use --attention-backend for an explicit override.
+set "VLLM_ATTENTION_BACKEND="
 if "%VLLM_CACHE_ROOT%"=="" set VLLM_CACHE_ROOT=C:\AI\vc
 if "%TRITON_CACHE_DIR%"=="" set TRITON_CACHE_DIR=C:\AI\vt
 
@@ -17,13 +21,27 @@ REM Safety: vLLM claims gpu-memory-utilization of the card and sizes the KV
 REM cache to fill whatever the weights leave over, so even a small model will
 REM allocate ~27 GiB by default. This card also drives the desktop, and RDNA4
 REM falls off a large-GEMM cliff under ~3 GiB free. Default to a conservative
-REM fraction unless the caller states one explicitly.
+REM fraction unless the caller states one explicitly. The wrapper settings
+REM below are optional; explicit CLI arguments always win.
+if "%WINDOWS_ROCM_GPU_MEMORY_UTILIZATION%"=="" set WINDOWS_ROCM_GPU_MEMORY_UTILIZATION=0.55
 echo %* | findstr /C:"gpu-memory-utilization" >nul
 if errorlevel 1 (
-  set VLLM_MEM_ARG=--gpu-memory-utilization 0.55
+  set "ROCM_MEM_ARG=--gpu-memory-utilization %WINDOWS_ROCM_GPU_MEMORY_UTILIZATION%"
 ) else (
-  set VLLM_MEM_ARG=
+  set "ROCM_MEM_ARG="
 )
 
-"%VENV%\Scripts\python.exe" -m vllm.entrypoints.cli.main bench %* %VLLM_MEM_ARG%
+set "ROCM_KV_ARG="
+if not "%WINDOWS_ROCM_KV_CACHE_DTYPE%"=="" (
+  echo %* | findstr /C:"kv-cache-dtype" >nul
+  if errorlevel 1 set "ROCM_KV_ARG=--kv-cache-dtype %WINDOWS_ROCM_KV_CACHE_DTYPE%"
+)
+
+set "ROCM_GRAPH_ARG="
+if not "%WINDOWS_ROCM_CUDAGRAPH_MODE%"=="" (
+  echo %* | findstr /C:"cudagraph_mode" >nul
+  if errorlevel 1 set "ROCM_GRAPH_ARG=-cc.cudagraph_mode=%WINDOWS_ROCM_CUDAGRAPH_MODE%"
+)
+
+"%VENV%\Scripts\python.exe" -m vllm.entrypoints.cli.main bench %* %ROCM_MEM_ARG% %ROCM_KV_ARG% %ROCM_GRAPH_ARG%
 exit /b %errorlevel%

--- a/benchmarks/kernels/benchmark_rocm_fp8_cudagraph.py
+++ b/benchmarks/kernels/benchmark_rocm_fp8_cudagraph.py
@@ -4,7 +4,8 @@
 
 Run this script through ``vram_guard.ps1`` on Windows. Channelwise mode mirrors
 vLLM's unfused per-token/per-channel fallback; rowwise mode exercises the fused
-hipBLASLt path that produces bf16 directly.
+hipBLASLt path that produces bf16 directly; Triton mode exercises vLLM's
+compressed-tensors scaled-MM kernel and checks it against channelwise output.
 """
 
 import argparse
@@ -23,6 +24,19 @@ def make_operands(m: int, n: int, k: int):
 
 
 def scaled_mm(mode: str, a, b, scale_a, scale_b):
+    if mode == "triton":
+        from vllm.model_executor.layers.quantization.compressed_tensors.triton_scaled_mm import (  # noqa: E501
+            triton_scaled_mm,
+        )
+
+        return triton_scaled_mm(
+            a,
+            b,
+            scale_a=scale_a,
+            scale_b=scale_b.t(),
+            out_dtype=torch.bfloat16,
+        )
+
     if mode == "rowwise":
         return torch._scaled_mm(
             a,
@@ -45,7 +59,9 @@ def scaled_mm(mode: str, a, b, scale_a, scale_b):
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--mode", choices=("channelwise", "rowwise"), required=True)
+    parser.add_argument(
+        "--mode", choices=("channelwise", "rowwise", "triton"), required=True
+    )
     parser.add_argument("--m", type=int, default=64)
     parser.add_argument("--n", type=int, default=4096)
     parser.add_argument("--k", type=int, default=4096)
@@ -82,6 +98,9 @@ def main() -> None:
     elapsed = time.perf_counter() - start
 
     torch.testing.assert_close(graph_output, eager_output, rtol=1e-2, atol=1e-2)
+    if args.mode == "triton":
+        reference = scaled_mm("channelwise", a, b, scale_a, scale_b)
+        torch.testing.assert_close(eager_output, reference, rtol=2e-2, atol=1e-1)
     tflops = 2 * args.m * args.n * args.k * args.replays / elapsed / 1e12
     print(f"PASS: {elapsed / args.replays * 1e3:.3f} ms, {tflops:.2f} TFLOPS")
 

--- a/benchmarks/kernels/benchmark_rocm_fp8_cudagraph.py
+++ b/benchmarks/kernels/benchmark_rocm_fp8_cudagraph.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Reproduce FP8 ``torch._scaled_mm`` HIP graph behavior on ROCm.
+
+Run this script through ``vram_guard.ps1`` on Windows. Channelwise mode mirrors
+vLLM's unfused per-token/per-channel fallback; rowwise mode exercises the fused
+hipBLASLt path that produces bf16 directly.
+"""
+
+import argparse
+import time
+
+import torch
+
+
+def make_operands(m: int, n: int, k: int):
+    fp8 = torch.float8_e4m3fn
+    a = torch.randn((m, k), device="cuda", dtype=torch.bfloat16).to(fp8)
+    b = torch.randn((n, k), device="cuda", dtype=torch.bfloat16).to(fp8).t()
+    scale_a = torch.full((m, 1), 0.01, device="cuda", dtype=torch.float32)
+    scale_b = torch.full((1, n), 0.01, device="cuda", dtype=torch.float32)
+    return a, b, scale_a, scale_b
+
+
+def scaled_mm(mode: str, a, b, scale_a, scale_b):
+    if mode == "rowwise":
+        return torch._scaled_mm(
+            a,
+            b,
+            scale_a=scale_a,
+            scale_b=scale_b,
+            out_dtype=torch.bfloat16,
+        )
+
+    one = torch.ones(1, device="cuda", dtype=torch.float32)
+    output = torch._scaled_mm(
+        a,
+        b,
+        scale_a=one,
+        scale_b=one,
+        out_dtype=torch.float32,
+    )
+    return (output * scale_a * scale_b).to(torch.bfloat16)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=("channelwise", "rowwise"), required=True)
+    parser.add_argument("--m", type=int, default=64)
+    parser.add_argument("--n", type=int, default=4096)
+    parser.add_argument("--k", type=int, default=4096)
+    parser.add_argument("--warmups", type=int, default=2)
+    parser.add_argument("--replays", type=int, default=10)
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available() or torch.version.hip is None:
+        raise RuntimeError("This benchmark requires a ROCm GPU")
+
+    print(
+        f"ROCm {torch.version.hip} | {torch.cuda.get_device_name()} | "
+        f"{args.mode=} | shape=({args.m}, {args.k}) x ({args.k}, {args.n})",
+        flush=True,
+    )
+    a, b, scale_a, scale_b = make_operands(args.m, args.n, args.k)
+
+    eager_output = scaled_mm(args.mode, a, b, scale_a, scale_b)
+    for _ in range(args.warmups):
+        scaled_mm(args.mode, a, b, scale_a, scale_b)
+    torch.cuda.synchronize()
+    print("eager warmup complete; capturing", flush=True)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_output = scaled_mm(args.mode, a, b, scale_a, scale_b)
+    print("capture complete; replaying", flush=True)
+
+    start = time.perf_counter()
+    for replay in range(args.replays):
+        graph.replay()
+        torch.cuda.synchronize()
+        print(f"replay {replay + 1}/{args.replays} complete", flush=True)
+    elapsed = time.perf_counter() - start
+
+    torch.testing.assert_close(graph_output, eager_output, rtol=1e-2, atol=1e-2)
+    tflops = 2 * args.m * args.n * args.k * args.replays / elapsed / 1e12
+    print(f"PASS: {elapsed / args.replays * 1e3:.3f} ms, {tflops:.2f} TFLOPS")
+
+
+if __name__ == "__main__":
+    main()

--- a/build_windows_rocm.cmd
+++ b/build_windows_rocm.cmd
@@ -1,0 +1,11 @@
+@echo off
+REM Build the vLLM C/HIP extensions in-place. See env_windows_rocm.cmd.
+setlocal
+
+if "%VLLM_ROOT%"=="" set VLLM_ROOT=%~dp0
+call "%VLLM_ROOT%env_windows_rocm.cmd"
+if errorlevel 1 exit /b 1
+
+cd /d "%VLLM_ROOT%"
+"%VENV%\Scripts\python.exe" setup.py build_ext --inplace %*
+exit /b %errorlevel%

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -3,8 +3,11 @@
 # `EXECUTABLE` and is one of the `SUPPORTED_VERSIONS`.
 #
 macro (find_python_from_executable EXECUTABLE SUPPORTED_VERSIONS)
-  file(REAL_PATH ${EXECUTABLE} EXECUTABLE)
-  set(Python_EXECUTABLE ${EXECUTABLE})
+  # Normalize first: on Windows the interpreter path arrives with backslashes,
+  # which cmake parses as escape sequences ("Invalid character escape '\A'").
+  file(TO_CMAKE_PATH "${EXECUTABLE}" EXECUTABLE)
+  file(REAL_PATH "${EXECUTABLE}" EXECUTABLE)
+  set(Python_EXECUTABLE "${EXECUTABLE}")
   find_package(Python COMPONENTS Interpreter Development.Module Development.SABIModule)
   if (NOT Python_FOUND)
     message(FATAL_ERROR "Unable to find python matching: ${EXECUTABLE}.")

--- a/csrc/attention/dtype_fp8.cuh
+++ b/csrc/attention/dtype_fp8.cuh
@@ -1,7 +1,11 @@
 #pragma once
 
 #include "attention_generic.cuh"
-#include "torch_utils.h"
+// Spelled relative to this file rather than as a bare "torch_utils.h", which
+// relies on the -Icsrc search path. There is a second, unrelated
+// libtorch_stable/torch_utils.h, and MSVC's include-stack search rules find
+// that one first when this header is pulled in from libtorch_stable/.
+#include "../torch_utils.h"
 
 #include <stdint.h>
 #ifdef ENABLE_FP8

--- a/csrc/cumem_allocator.cpp
+++ b/csrc/cumem_allocator.cpp
@@ -3,6 +3,12 @@
 // need to be unsigned long long
 #include <iostream>
 
+#if defined(_WIN32)
+  // ssize_t is POSIX; MSVC only ships the equivalent as SSIZE_T.
+  #include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 #include "cumem_allocator_compat.h"
 
 #ifndef USE_ROCM

--- a/csrc/fs_io.cpp
+++ b/csrc/fs_io.cpp
@@ -3,7 +3,17 @@
 
 #include <Python.h>
 
-#include <unistd.h>
+#if defined(_WIN32)
+  // Windows has no <unistd.h>; _access() in <io.h> is the equivalent, and
+  // F_OK (existence check) is simply mode 0.
+  #include <io.h>
+  #define access _access
+  #ifndef F_OK
+    #define F_OK 0
+  #endif
+#else
+  #include <unistd.h>
+#endif
 
 #include <vector>
 

--- a/csrc/libtorch_stable/activation_kernels.cu
+++ b/csrc/libtorch_stable/activation_kernels.cu
@@ -3,6 +3,19 @@
 
 #include <cmath>
 
+// The M_* constants are a POSIX extension. MSVC only exposes them when
+// _USE_MATH_DEFINES is defined before <cmath> is first included, which cannot
+// be guaranteed here because the torch headers above pull it in transitively.
+#ifndef M_SQRT1_2
+  #define M_SQRT1_2 0.70710678118654752440
+#endif
+#ifndef M_SQRT2
+  #define M_SQRT2 1.41421356237309504880
+#endif
+#ifndef M_2_SQRTPI
+  #define M_2_SQRTPI 1.12837916709551257390
+#endif
+
 #include "../cuda_compat.h"
 #include "cuda_vec_utils.cuh"
 #include "dispatch_utils.h"

--- a/csrc/libtorch_stable/mamba/selective_scan_fwd.cu
+++ b/csrc/libtorch_stable/mamba/selective_scan_fwd.cu
@@ -4,6 +4,13 @@
 #include <torch/csrc/stable/macros.h>
 #include "selective_scan.h"
 
+// M_LOG2E is a POSIX extension. MSVC only exposes it when _USE_MATH_DEFINES is
+// defined before <cmath> is first included, which cannot be guaranteed here
+// because the headers above pull it in transitively.
+#ifndef M_LOG2E
+    #define M_LOG2E 1.44269504088896340736
+#endif
+
 #ifndef USE_ROCM
     #include <cub/block/block_load.cuh>
     #include <cub/block/block_store.cuh>

--- a/csrc/spinloop.cpp
+++ b/csrc/spinloop.cpp
@@ -8,9 +8,49 @@ extern "C" {
 #if defined(__i386__) || defined(__x86_64__)
   #include <cpuid.h>
   #include <mwaitxintrin.h>
+
+// clang refuses to expand the monitorx/mwaitx intrinsics inside a function that
+// was not compiled with the 'mwaitx' target feature, even though every call
+// site is already guarded at runtime by the cpuid check in
+// determine_cpu_support(). GCC accepts them unconditionally. Wrapping them in
+// functions that carry the target attribute keeps the runtime guard as the only
+// thing gating execution, and costs a regular (non-inlined) call.
+  #if defined(__clang__)
+    #define VLLM_MWAITX_TARGET __attribute__((target("mwaitx")))
+  #else
+    #define VLLM_MWAITX_TARGET
+  #endif
+
+VLLM_MWAITX_TARGET static void vllm_monitorx(void* addr, unsigned int extensions,
+                                             unsigned int hints) {
+  _mm_monitorx(addr, extensions, hints);
+}
+
+VLLM_MWAITX_TARGET static void vllm_mwaitx(unsigned int extensions,
+                                           unsigned int hints,
+                                           unsigned int clock) {
+  _mm_mwaitx(extensions, hints, clock);
+}
 #endif
 
-#if defined(CLOCK_MONOTONIC_RAW)
+#if defined(_WIN32)
+// Windows has no clock_gettime(). MSVC's <time.h> does provide struct timespec
+// (C11), so only the monotonic clock itself needs supplying.
+  #include <windows.h>
+
+  #define TIMEOUT_CLOCK 0
+
+static int clock_gettime(int /*clk_id*/, struct timespec* ts) {
+  LARGE_INTEGER freq, ctr;
+  if (!QueryPerformanceFrequency(&freq) || !QueryPerformanceCounter(&ctr)) {
+    return -1;
+  }
+  ts->tv_sec = (time_t)(ctr.QuadPart / freq.QuadPart);
+  ts->tv_nsec =
+      (long)(((ctr.QuadPart % freq.QuadPart) * 1000000000LL) / freq.QuadPart);
+  return 0;
+}
+#elif defined(CLOCK_MONOTONIC_RAW)
   #define TIMEOUT_CLOCK CLOCK_MONOTONIC_RAW
 #else
   #define TIMEOUT_CLOCK CLOCK_MONOTONIC
@@ -126,7 +166,7 @@ static PyObject* method_spinloop(PyObject* self, PyObject* args,
 #if defined(__i386__) || defined(__x86_64__)
     // monitorx + mwaitx with qualified buffer
     if (buffer_qualifies && state->cpu_support == CPU_SUPPORT_MONITORX) {
-      _mm_monitorx(buffer.buf, 0, 0);
+      vllm_monitorx(buffer.buf, 0, 0);
 
       // Check once more in case the buffer has been modified while we were
       // arming the monitor hardware
@@ -146,8 +186,8 @@ static PyObject* method_spinloop(PyObject* self, PyObject* args,
       // Run mwaitx with enabled timeout (bit 1). The actual timeout value
       // is not very important, we just want to ensure we don't lock up
       // here for too long.
-      Py_BEGIN_ALLOW_THREADS _mm_mwaitx((1 << 1), 0,
-                                        MWAITX_DEFAULT_TIMEOUT_CYCLES);
+      Py_BEGIN_ALLOW_THREADS vllm_mwaitx((1 << 1), 0,
+                                         MWAITX_DEFAULT_TIMEOUT_CYCLES);
       Py_END_ALLOW_THREADS
     }
 

--- a/env_windows_rocm.cmd
+++ b/env_windows_rocm.cmd
@@ -1,6 +1,6 @@
 @echo off
 REM =====================================================================
-REM Shared build environment for native Windows + ROCm (gfx1201 / RDNA4).
+REM Shared build environment for native Windows + ROCm (gfx1200/gfx1201).
 REM Dot-sourced by build_windows_rocm.cmd and install_windows_rocm.cmd.
 REM Deliberately has no setlocal: the caller owns the scope.
 REM
@@ -35,7 +35,8 @@ set PATH=%ROCM_ROOT%\bin;%ROCM_ROOT%\lib\llvm\bin;%VENV%\Scripts;%PATH%
 
 REM --- vLLM build configuration ----------------------------------------
 set VLLM_TARGET_DEVICE=rocm
-set PYTORCH_ROCM_ARCH=gfx1201
+if "%VLLM_ROCM_GPU_ARCH%"=="" set VLLM_ROCM_GPU_ARCH=gfx1201
+set PYTORCH_ROCM_ARCH=%VLLM_ROCM_GPU_ARCH%
 if "%MAX_JOBS%"=="" set MAX_JOBS=16
 
 REM setup.py appends $CMAKE_ARGS verbatim, and later -D wins for cache vars,
@@ -43,7 +44,7 @@ REM so this also overrides the -DROCM_PATH that setup.py derives from torch.
 set CMAKE_ARGS=-DCMAKE_CXX_COMPILER=%ROCM_ROOT_FWD%/lib/llvm/bin/clang-cl.exe ^
  -DCMAKE_HIP_COMPILER=%ROCM_ROOT_FWD%/lib/llvm/bin/clang-cl.exe ^
  -DCMAKE_HIP_PLATFORM=amd ^
- -DCMAKE_HIP_ARCHITECTURES=gfx1201 ^
+ -DCMAKE_HIP_ARCHITECTURES=%VLLM_ROCM_GPU_ARCH% ^
  -DCMAKE_HIP_FLAGS=--rocm-device-lib-path=%ROCM_ROOT_FWD%/lib/llvm/amdgcn/bitcode ^
  -DROCM_PATH=%ROCM_ROOT_FWD%
 

--- a/env_windows_rocm.cmd
+++ b/env_windows_rocm.cmd
@@ -1,0 +1,54 @@
+@echo off
+REM =====================================================================
+REM Shared build environment for native Windows + ROCm (gfx1201 / RDNA4).
+REM Dot-sourced by build_windows_rocm.cmd and install_windows_rocm.cmd.
+REM Deliberately has no setlocal: the caller owns the scope.
+REM
+REM Requires:
+REM   - Visual Studio 2022 Build Tools (for the Windows SDK + libs)
+REM   - .venv211 with torch+rocm, rocm-sdk-devel, cmake>=4.4, ninja
+REM
+REM Notes learned the hard way:
+REM   - CMake >= 4.4 is REQUIRED. 3.31 cannot configure HIP with clang-cl.
+REM   - clang-cl must be used for BOTH CXX and HIP; CMake refuses to mix
+REM     a GNU-style driver for HIP with MSVC cl for C++.
+REM   - ROCM_PATH/HIP_PATH must use forward slashes.
+REM =====================================================================
+
+if "%VLLM_ROOT%"=="" set VLLM_ROOT=%~dp0
+set VENV=%VLLM_ROOT%.venv211
+
+REM --- MSVC environment (vcvars64 invokes vswhere by bare name) ---------
+set PATH=C:\Program Files (x86)\Microsoft Visual Studio\Installer;%PATH%
+call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat" >nul
+if errorlevel 1 (echo [FAIL] vcvars64 & exit /b 1)
+
+REM --- ROCm SDK location, from the wheel itself ------------------------
+for /f "delims=" %%i in ('"%VENV%\Scripts\python.exe" -m rocm_sdk path --root') do set ROCM_ROOT=%%i
+set ROCM_ROOT_FWD=%ROCM_ROOT:\=/%
+
+REM CMake interpolates these into generated cmake code unescaped, so
+REM backslashes surface as "Invalid character escape". Forward slashes only.
+set ROCM_PATH=%ROCM_ROOT_FWD%
+set HIP_PATH=%ROCM_ROOT_FWD%
+set PATH=%ROCM_ROOT%\bin;%ROCM_ROOT%\lib\llvm\bin;%VENV%\Scripts;%PATH%
+
+REM --- vLLM build configuration ----------------------------------------
+set VLLM_TARGET_DEVICE=rocm
+set PYTORCH_ROCM_ARCH=gfx1201
+if "%MAX_JOBS%"=="" set MAX_JOBS=16
+
+REM setup.py appends $CMAKE_ARGS verbatim, and later -D wins for cache vars,
+REM so this also overrides the -DROCM_PATH that setup.py derives from torch.
+set CMAKE_ARGS=-DCMAKE_CXX_COMPILER=%ROCM_ROOT_FWD%/lib/llvm/bin/clang-cl.exe ^
+ -DCMAKE_HIP_COMPILER=%ROCM_ROOT_FWD%/lib/llvm/bin/clang-cl.exe ^
+ -DCMAKE_HIP_PLATFORM=amd ^
+ -DCMAKE_HIP_ARCHITECTURES=gfx1201 ^
+ -DCMAKE_HIP_FLAGS=--rocm-device-lib-path=%ROCM_ROOT_FWD%/lib/llvm/amdgcn/bitcode ^
+ -DROCM_PATH=%ROCM_ROOT_FWD%
+
+echo === ROCM_ROOT   : %ROCM_ROOT%
+echo === TARGET      : %VLLM_TARGET_DEVICE% / %PYTORCH_ROCM_ARCH%
+echo === MAX_JOBS    : %MAX_JOBS%
+echo.
+exit /b 0

--- a/install_windows_rocm.cmd
+++ b/install_windows_rocm.cmd
@@ -1,0 +1,14 @@
+@echo off
+REM Editable-install vLLM into .venv211 so importlib.metadata can see it.
+REM --no-deps: requirements/common.txt is installed separately; the ROCm and
+REM CUDA requirement files pull Linux-only packages.
+REM --no-build-isolation: the build needs this venv's torch and cmake>=4.4.
+setlocal
+
+if "%VLLM_ROOT%"=="" set VLLM_ROOT=%~dp0
+call "%VLLM_ROOT%env_windows_rocm.cmd"
+if errorlevel 1 exit /b 1
+
+cd /d "%VLLM_ROOT%"
+uv pip install --python "%VENV%\Scripts\python.exe" -e . --no-deps --no-build-isolation %*
+exit /b %errorlevel%

--- a/quantize_fp8.py
+++ b/quantize_fp8.py
@@ -1,0 +1,99 @@
+"""Convert a HF checkpoint to FP8 W8A8 (compressed-tensors) for vLLM on RDNA4.
+
+FP8 e4m3fn is the fastest format this card has a matrix path for: ~236 TFLOPS
+measured on gfx1201 versus ~130 for bf16. The FP8_DYNAMIC recipe is per-channel
+weight scales plus per-token dynamic activation scales, so it needs no
+calibration data and runs entirely on CPU -- which matters here, because the
+GPU only has 32 GB and the bigger targets do not fit twice.
+
+Run with the isolated quantization venv, not the serving one:
+    .venv-quant\\Scripts\\python.exe quantize_fp8.py <model> [output_dir]
+
+llmcompressor pins transformers<=5.10.1 while vLLM wants a newer one, which is
+why the two environments are kept apart.
+"""
+
+import argparse
+import os
+from pathlib import Path
+
+if not hasattr(os, "sysconf"):
+    # compressed_tensors sizes the CPU offload budget with os.sysconf(), which
+    # only exists on POSIX. Report the same number Windows would: total
+    # physical RAM, expressed as page size x page count.
+    import ctypes
+
+    def _sysconf(name: str) -> int:
+        class MemoryStatusEx(ctypes.Structure):
+            _fields_ = [
+                ("dwLength", ctypes.c_ulong),
+                ("dwMemoryLoad", ctypes.c_ulong),
+                ("ullTotalPhys", ctypes.c_ulonglong),
+                ("ullAvailPhys", ctypes.c_ulonglong),
+                ("ullTotalPageFile", ctypes.c_ulonglong),
+                ("ullAvailPageFile", ctypes.c_ulonglong),
+                ("ullTotalVirtual", ctypes.c_ulonglong),
+                ("ullAvailVirtual", ctypes.c_ulonglong),
+                ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+            ]
+
+        page_size = 4096
+        if name == "SC_PAGE_SIZE":
+            return page_size
+        if name == "SC_PHYS_PAGES":
+            status = MemoryStatusEx()
+            status.dwLength = ctypes.sizeof(MemoryStatusEx)
+            ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(status))
+            return int(status.ullTotalPhys) // page_size
+        raise ValueError(f"unsupported sysconf name: {name}")
+
+    os.sysconf = _sysconf
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("model", help="HF repo id or local path")
+    parser.add_argument(
+        "output_dir",
+        nargs="?",
+        default=None,
+        help="where to write the quantized checkpoint "
+        "(default: C:\\AI\\models\\<name>-FP8-Dynamic)",
+    )
+    args = parser.parse_args()
+
+    out = args.output_dir
+    if out is None:
+        name = args.model.rstrip("/\\").split("/")[-1].split("\\")[-1]
+        out = str(Path(r"C:\AI\models") / f"{name}-FP8-Dynamic")
+    os.makedirs(out, exist_ok=True)
+
+    import torch
+    from llmcompressor import oneshot
+    from llmcompressor.modifiers.quantization import QuantizationModifier
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    print(f"Loading {args.model} on CPU in bfloat16 ...")
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model, dtype=torch.bfloat16, device_map="cpu"
+    )
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+
+    recipe = QuantizationModifier(
+        targets="Linear",
+        scheme="FP8_DYNAMIC",
+        # lm_head stays in bf16: it is a single large GEMM whose output feeds
+        # the sampler directly, so quantizing it costs accuracy for very little
+        # memory, and vLLM does not run it through the FP8 path anyway.
+        ignore=["lm_head"],
+    )
+
+    print(f"Quantizing to FP8 W8A8 -> {out}")
+    oneshot(model=model, recipe=recipe, output_dir=out, tokenizer=tokenizer)
+
+    total = sum(f.stat().st_size for f in Path(out).rglob("*") if f.is_file())
+    print(f"Done. {out} is {total / 2**30:.2f} GiB")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -21,10 +21,10 @@ pillow  # Required for image processing
 prometheus-fastapi-instrumentator >= 8.0.0 # v8 unblocks starlette >= 1.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer == 0.11.3
-llguidance >= 1.7.0, < 1.8.0; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "s390x"
+llguidance >= 1.7.0, < 1.8.0; platform_machine == "x86_64" or platform_machine == "AMD64" or platform_machine == "arm64" or platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "s390x"
 outlines_core == 0.2.14
 lark == 1.2.2
-xgrammar >= 0.2.1, < 1.0.0; platform_machine == "x86_64" or platform_machine == "aarch64" or platform_machine == "arm64" or platform_machine == "s390x" or platform_machine == "ppc64le"
+xgrammar >= 0.2.1, < 1.0.0; platform_machine == "x86_64" or platform_machine == "AMD64" or platform_machine == "aarch64" or platform_machine == "arm64" or platform_machine == "s390x" or platform_machine == "ppc64le"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317
 partial-json-parser # used for parsing partial JSON outputs

--- a/serve_windows_rocm.cmd
+++ b/serve_windows_rocm.cmd
@@ -3,8 +3,10 @@ REM Run `vllm serve` on native Windows + ROCm (gfx1201 / RDNA4).
 REM Usage: serve_windows_rocm.cmd <model> [extra vllm serve args...]
 setlocal
 
-if "%VLLM_ROOT%"=="" set VLLM_ROOT=%~dp0
-set VENV=%VLLM_ROOT%.venv211
+set "ROCM_VLLM_ROOT=%~dp0"
+if not "%VLLM_ROOT%"=="" set "ROCM_VLLM_ROOT=%VLLM_ROOT%"
+set "VLLM_ROOT="
+set "VENV=%ROCM_VLLM_ROOT%.venv211"
 
 REM rocBLAS has no tuned gfx1201 kernels; without this bf16/fp16 GEMMs run ~10x slow.
 set TORCH_BLAS_PREFER_HIPBLASLT=1
@@ -12,9 +14,9 @@ set TORCH_BLAS_PREFER_HIPBLASLT=1
 REM Windows has no fork.
 set VLLM_WORKER_MULTIPROC_METHOD=spawn
 
-REM gfx1201 compiles none of vLLM's ROCm attention kernels (they are ISA-gated
-REM to gfx9/gfx11/gfx1100), so Triton is the only working backend.
-set VLLM_ATTENTION_BACKEND=TRITON_ATTN
+REM VLLM_ATTENTION_BACKEND was removed upstream. The ROCm platform chooses
+REM ROCM_ATTN by default; use --attention-backend for an explicit override.
+set "VLLM_ATTENTION_BACKEND="
 
 REM Short cache roots: LongPathsEnabled is off, and the default Inductor cache
 REM path overflows MAX_PATH (260) by a couple of characters.
@@ -25,13 +27,27 @@ REM Safety: vLLM claims gpu-memory-utilization of the card and sizes the KV
 REM cache to fill whatever the weights leave over, so even a small model will
 REM allocate ~27 GiB by default. This card also drives the desktop, and RDNA4
 REM falls off a large-GEMM cliff under ~3 GiB free. Default to a conservative
-REM fraction unless the caller states one explicitly.
+REM fraction unless the caller states one explicitly. The wrapper settings
+REM below are optional; explicit CLI arguments always win.
+if "%WINDOWS_ROCM_GPU_MEMORY_UTILIZATION%"=="" set WINDOWS_ROCM_GPU_MEMORY_UTILIZATION=0.55
 echo %* | findstr /C:"gpu-memory-utilization" >nul
 if errorlevel 1 (
-  set VLLM_MEM_ARG=--gpu-memory-utilization 0.55
+  set "ROCM_MEM_ARG=--gpu-memory-utilization %WINDOWS_ROCM_GPU_MEMORY_UTILIZATION%"
 ) else (
-  set VLLM_MEM_ARG=
+  set "ROCM_MEM_ARG="
 )
 
-"%VENV%\Scripts\python.exe" -m vllm.entrypoints.cli.main serve %* %VLLM_MEM_ARG%
+set "ROCM_KV_ARG="
+if not "%WINDOWS_ROCM_KV_CACHE_DTYPE%"=="" (
+  echo %* | findstr /C:"kv-cache-dtype" >nul
+  if errorlevel 1 set "ROCM_KV_ARG=--kv-cache-dtype %WINDOWS_ROCM_KV_CACHE_DTYPE%"
+)
+
+set "ROCM_GRAPH_ARG="
+if not "%WINDOWS_ROCM_CUDAGRAPH_MODE%"=="" (
+  echo %* | findstr /C:"cudagraph_mode" >nul
+  if errorlevel 1 set "ROCM_GRAPH_ARG=-cc.cudagraph_mode=%WINDOWS_ROCM_CUDAGRAPH_MODE%"
+)
+
+"%VENV%\Scripts\python.exe" -m vllm.entrypoints.cli.main serve %* %ROCM_MEM_ARG% %ROCM_KV_ARG% %ROCM_GRAPH_ARG%
 exit /b %errorlevel%

--- a/serve_windows_rocm.cmd
+++ b/serve_windows_rocm.cmd
@@ -1,0 +1,37 @@
+@echo off
+REM Run `vllm serve` on native Windows + ROCm (gfx1201 / RDNA4).
+REM Usage: serve_windows_rocm.cmd <model> [extra vllm serve args...]
+setlocal
+
+if "%VLLM_ROOT%"=="" set VLLM_ROOT=%~dp0
+set VENV=%VLLM_ROOT%.venv211
+
+REM rocBLAS has no tuned gfx1201 kernels; without this bf16/fp16 GEMMs run ~10x slow.
+set TORCH_BLAS_PREFER_HIPBLASLT=1
+
+REM Windows has no fork.
+set VLLM_WORKER_MULTIPROC_METHOD=spawn
+
+REM gfx1201 compiles none of vLLM's ROCm attention kernels (they are ISA-gated
+REM to gfx9/gfx11/gfx1100), so Triton is the only working backend.
+set VLLM_ATTENTION_BACKEND=TRITON_ATTN
+
+REM Short cache roots: LongPathsEnabled is off, and the default Inductor cache
+REM path overflows MAX_PATH (260) by a couple of characters.
+if "%VLLM_CACHE_ROOT%"=="" set VLLM_CACHE_ROOT=C:\AI\vc
+if "%TRITON_CACHE_DIR%"=="" set TRITON_CACHE_DIR=C:\AI\vt
+
+REM Safety: vLLM claims gpu-memory-utilization of the card and sizes the KV
+REM cache to fill whatever the weights leave over, so even a small model will
+REM allocate ~27 GiB by default. This card also drives the desktop, and RDNA4
+REM falls off a large-GEMM cliff under ~3 GiB free. Default to a conservative
+REM fraction unless the caller states one explicitly.
+echo %* | findstr /C:"gpu-memory-utilization" >nul
+if errorlevel 1 (
+  set VLLM_MEM_ARG=--gpu-memory-utilization 0.55
+) else (
+  set VLLM_MEM_ARG=
+)
+
+"%VENV%\Scripts\python.exe" -m vllm.entrypoints.cli.main serve %* %VLLM_MEM_ARG%
+exit /b %errorlevel%

--- a/setup.py
+++ b/setup.py
@@ -81,15 +81,21 @@ def has_precompiled_rust_extensions() -> bool:
 if sys.platform.startswith("darwin") and VLLM_TARGET_DEVICE != "cpu":
     logger.warning("VLLM_TARGET_DEVICE automatically set to `cpu` due to macOS")
     VLLM_TARGET_DEVICE = "cpu"
-elif not (sys.platform.startswith("linux") or sys.platform.startswith("darwin")):
+elif not (
+    sys.platform.startswith("linux")
+    or sys.platform.startswith("darwin")
+    or sys.platform == "win32"
+):
     logger.warning(
-        "vLLM only supports Linux platform (including WSL) and MacOS."
+        "vLLM only supports Linux platform (including WSL), MacOS and Windows."
         "Building on %s, "
         "so vLLM may not be able to run correctly",
         sys.platform,
     )
     VLLM_TARGET_DEVICE = "empty"
-elif sys.platform.startswith("linux") and os.getenv("VLLM_TARGET_DEVICE") is None:
+elif (
+    sys.platform.startswith("linux") or sys.platform == "win32"
+) and os.getenv("VLLM_TARGET_DEVICE") is None:
     if torch.version.hip is not None:
         VLLM_TARGET_DEVICE = "rocm"
         logger.info("Auto-detected ROCm")
@@ -101,6 +107,15 @@ elif sys.platform.startswith("linux") and os.getenv("VLLM_TARGET_DEVICE") is Non
         logger.info("Auto-detected CUDA")
     else:
         VLLM_TARGET_DEVICE = "cpu"
+
+
+def _cmake_path(path: str) -> str:
+    """Normalize a filesystem path for embedding in a cmake argument.
+
+    cmake interprets backslashes as escape sequences, so Windows paths must be
+    passed with forward slashes. No-op on POSIX.
+    """
+    return path.replace("\\", "/")
 
 
 def is_sccache_available() -> bool:
@@ -274,12 +289,22 @@ class cmake_build_ext(build_ext):
             ]
 
         # Pass the python executable to cmake so it can find an exact
-        # match.
-        cmake_args += ["-DVLLM_PYTHON_EXECUTABLE={}".format(sys.executable)]
+        # match. Paths are normalized to forward slashes because cmake treats
+        # backslashes as escape sequences: a Windows path like
+        # `C:\AI\vllm\.venv\Scripts\python.exe` fails to parse with
+        # "Invalid character escape '\A'". Forward slashes work on all
+        # platforms, and this is a no-op on POSIX.
+        cmake_args += [
+            "-DVLLM_PYTHON_EXECUTABLE={}".format(_cmake_path(sys.executable))
+        ]
 
         # Pass the python path to cmake so it can reuse the build dependencies
         # on subsequent calls to python.
-        cmake_args += ["-DVLLM_PYTHON_PATH={}".format(":".join(sys.path))]
+        cmake_args += [
+            "-DVLLM_PYTHON_PATH={}".format(
+                os.pathsep.join(_cmake_path(p) for p in sys.path)
+            )
+        ]
 
         # Override the base directory for FetchContent downloads to $ROOT/.deps
         # This allows sharing dependencies between profiles,
@@ -287,7 +312,7 @@ class cmake_build_ext(build_ext):
         # To override this, set the FETCHCONTENT_BASE_DIR environment variable.
         fc_base_dir = os.path.join(ROOT_DIR, ".deps")
         fc_base_dir = os.environ.get("FETCHCONTENT_BASE_DIR", fc_base_dir)
-        cmake_args += ["-DFETCHCONTENT_BASE_DIR={}".format(fc_base_dir)]
+        cmake_args += ["-DFETCHCONTENT_BASE_DIR={}".format(_cmake_path(fc_base_dir))]
 
         #
         # Setup parallelism and build tool

--- a/setup_windows_rocm.ps1
+++ b/setup_windows_rocm.ps1
@@ -8,7 +8,7 @@
     - validates the required Windows, AMD, uv, Git, and Visual Studio setup;
     - creates or reuses .venv211 with Python 3.12;
     - installs the pinned AMD ROCm/PyTorch, Triton, and build dependencies;
-    - probes the AMD GPU through vram_guard.ps1 and requires gfx1201;
+    - probes the AMD GPU through vram_guard.ps1 and requires the selected GFX architecture;
     - builds and editable-installs this vLLM fork; and
     - performs a second guarded import/device verification.
 
@@ -18,6 +18,10 @@
 
 .PARAMETER MaxJobs
     Maximum parallel native build jobs. Defaults to 16.
+
+.PARAMETER GpuArch
+    AMD GFX architecture to verify and compile for. Supported values are
+    gfx1200 and gfx1201. Defaults to gfx1201 for backward compatibility.
 
 .PARAMETER GuardLimitGiB
     Dedicated-VRAM kill threshold used for the guarded GPU probes.
@@ -34,11 +38,17 @@
 
 .EXAMPLE
     .\setup_windows_rocm.ps1
+
+.EXAMPLE
+    .\setup_windows_rocm.ps1 -GpuArch gfx1200 -MaxJobs 6 -GuardWarnGiB 13 -GuardLimitGiB 14.5
 #>
 #Requires -Version 5.1
 
 [CmdletBinding()]
 param(
+    [ValidateSet('gfx1200', 'gfx1201')]
+    [string]$GpuArch = 'gfx1201',
+
     [ValidateRange(1, 256)]
     [int]$MaxJobs = 16,
 
@@ -56,7 +66,7 @@ $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 
 $ExpectedPython = '3.12'
-$ExpectedGpuArch = 'gfx1201'
+$ExpectedGpuArch = $GpuArch
 $TorchVersion = '2.11.0+rocm7.13.0'
 $TorchvisionVersion = '0.26.0+rocm7.13.0'
 $RocmVersion = '7.13.0'
@@ -253,7 +263,7 @@ if ($PlanOnly) {
     Write-Step 'Plan'
     Write-Host '1. Create or reuse .venv211 with Python 3.12.'
     Write-Host '2. Install the pinned ROCm 7.13, PyTorch 2.11, and Triton stack.'
-    Write-Host '3. Run a fail-closed guarded Torch/HIP/gfx1201 probe.'
+    Write-Host "3. Run a fail-closed guarded Torch/HIP/$ExpectedGpuArch probe."
     Write-Host '4. Build the native C++/HIP extensions with clang-cl.'
     Write-Host '5. Editable-install vLLM and run a guarded import/device probe.'
     Write-Host "`nPlanOnly completed; no files, packages, GPU contexts, or builds were changed."
@@ -279,7 +289,7 @@ else {
 }
 
 $pythonVersion = & $VenvPython -c `
-    'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")'
+    'import sys; print(sys.version_info.major, sys.version_info.minor, sep=chr(46))'
 if ($LASTEXITCODE -ne 0 -or $pythonVersion.Trim() -ne $ExpectedPython) {
     throw "$Venv must contain Python $ExpectedPython; found '$pythonVersion'."
 }
@@ -347,16 +357,18 @@ print(json.dumps(result, sort_keys=True))
 if architecture_base != '$ExpectedGpuArch':
     raise SystemExit(
         f'Expected $ExpectedGpuArch, but Torch reported {architecture}. '
-        'This setup script only automates the tested R9700/RDNA4 target.'
+        'Select the matching architecture with -GpuArch and rebuild.'
     )
 "@
 Invoke-GuardedProbe -Name 'ROCm device verification' -PythonCode $torchProbe
 
 $previousMaxJobs = [Environment]::GetEnvironmentVariable('MAX_JOBS', 'Process')
 $previousVllmRoot = [Environment]::GetEnvironmentVariable('VLLM_ROOT', 'Process')
+$previousGpuArch = [Environment]::GetEnvironmentVariable('VLLM_ROCM_GPU_ARCH', 'Process')
 try {
     $env:MAX_JOBS = [string]$MaxJobs
     $env:VLLM_ROOT = $Root + '\'
+    $env:VLLM_ROCM_GPU_ARCH = $ExpectedGpuArch
 
     Invoke-Native `
         'Build vLLM native Windows ROCm extensions' `
@@ -377,6 +389,11 @@ finally {
     [Environment]::SetEnvironmentVariable(
         'VLLM_ROOT',
         $previousVllmRoot,
+        'Process'
+    )
+    [Environment]::SetEnvironmentVariable(
+        'VLLM_ROCM_GPU_ARCH',
+        $previousGpuArch,
         'Process'
     )
 }

--- a/setup_windows_rocm.ps1
+++ b/setup_windows_rocm.ps1
@@ -1,0 +1,404 @@
+<#
+.SYNOPSIS
+    Prepare, build, and verify the tested native-Windows ROCm vLLM stack.
+
+.DESCRIPTION
+    Automates the repository-local parts of the Windows ROCm installation:
+
+    - validates the required Windows, AMD, uv, Git, and Visual Studio setup;
+    - creates or reuses .venv211 with Python 3.12;
+    - installs the pinned AMD ROCm/PyTorch, Triton, and build dependencies;
+    - probes the AMD GPU through vram_guard.ps1 and requires gfx1201;
+    - builds and editable-installs this vLLM fork; and
+    - performs a second guarded import/device verification.
+
+    It deliberately does not install or update the AMD display driver, Visual
+    Studio, Git, uv, or model weights. System-wide installers require explicit
+    user review, and models have separate licenses and storage requirements.
+
+.PARAMETER MaxJobs
+    Maximum parallel native build jobs. Defaults to 16.
+
+.PARAMETER GuardLimitGiB
+    Dedicated-VRAM kill threshold used for the guarded GPU probes.
+
+.PARAMETER GuardWarnGiB
+    Dedicated-VRAM warning threshold used for the guarded GPU probes.
+
+.PARAMETER PlanOnly
+    Validate system prerequisites and print the planned work without changing
+    the environment, downloading packages, probing the GPU, or building vLLM.
+
+.EXAMPLE
+    .\setup_windows_rocm.ps1 -PlanOnly
+
+.EXAMPLE
+    .\setup_windows_rocm.ps1
+#>
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param(
+    [ValidateRange(1, 256)]
+    [int]$MaxJobs = 16,
+
+    [ValidateRange(1.0, 256.0)]
+    [double]$GuardLimitGiB = 26.0,
+
+    [ValidateRange(0.0, 256.0)]
+    [double]$GuardWarnGiB = 23.0,
+
+    [switch]$PlanOnly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$ExpectedPython = '3.12'
+$ExpectedGpuArch = 'gfx1201'
+$TorchVersion = '2.11.0+rocm7.13.0'
+$TorchvisionVersion = '0.26.0+rocm7.13.0'
+$RocmVersion = '7.13.0'
+$TritonVersion = '3.6.0.post26'
+$AmdWheelIndex = 'https://repo.amd.com/rocm/whl/gfx120X-all/'
+
+$Root = (Resolve-Path -LiteralPath $PSScriptRoot).Path.TrimEnd('\')
+$Venv = Join-Path $Root '.venv211'
+$VenvPython = Join-Path $Venv 'Scripts\python.exe'
+$Requirements = Join-Path $Root 'requirements\common.txt'
+$BuildScript = Join-Path $Root 'build_windows_rocm.cmd'
+$InstallScript = Join-Path $Root 'install_windows_rocm.cmd'
+$GuardScript = Join-Path $Root 'vram_guard.ps1'
+$Vcvars = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat'
+
+function Write-Step([string]$Message) {
+    Write-Host "`n=== $Message ===" -ForegroundColor Cyan
+}
+
+function Write-Detail([string]$Name, [string]$Value) {
+    Write-Host ('{0,-18} {1}' -f ($Name + ':'), $Value)
+}
+
+function Invoke-Native(
+    [string]$Description,
+    [string]$FilePath,
+    [string[]]$ArgumentList
+) {
+    Write-Step $Description
+    & $FilePath @ArgumentList
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw "$Description failed with exit code $exitCode."
+    }
+}
+
+function Get-RequiredApplication([string]$Name, [string]$InstallHint) {
+    $command = Get-Command $Name -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($null -eq $command) {
+        throw "$Name was not found on PATH. $InstallHint"
+    }
+    return $command.Source
+}
+
+function Invoke-GuardedProbe([string]$Name, [string]$PythonCode) {
+    $logs = Join-Path $Root 'logs'
+    [void](New-Item -ItemType Directory -Path $logs -Force)
+
+    $stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $safeName = $Name.ToLowerInvariant().Replace(' ', '-')
+    $probeLog = Join-Path $logs "setup-$safeName-$stamp.log"
+    $guardLog = Join-Path $logs "setup-$safeName-$stamp.guard.log"
+    $probeFile = Join-Path ([IO.Path]::GetTempPath()) (
+        'vllm-windows-rocm-probe-{0}.py' -f [guid]::NewGuid().ToString('N')
+    )
+
+    [IO.File]::WriteAllText(
+        $probeFile,
+        $PythonCode,
+        [Text.UTF8Encoding]::new($false)
+    )
+
+    try {
+        $command = '"{0}" "{1}" > "{2}" 2>&1' -f (
+            $VenvPython,
+            $probeFile,
+            $probeLog
+        )
+
+        Write-Step "$Name (guarded)"
+        & $GuardScript `
+            -Command $command `
+            -LimitGiB $GuardLimitGiB `
+            -WarnGiB $GuardWarnGiB `
+            -StallLogPath $probeLog `
+            -StallSec 180 `
+            -LogPath $guardLog
+        $exitCode = $LASTEXITCODE
+
+        if (Test-Path -LiteralPath $probeLog) {
+            Get-Content -LiteralPath $probeLog
+        }
+        if ($exitCode -ne 0) {
+            throw "$Name failed under the VRAM guard with exit code $exitCode. See $guardLog"
+        }
+    }
+    finally {
+        Remove-Item -LiteralPath $probeFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Step 'Preflight checks'
+
+if ($env:OS -ne 'Windows_NT') {
+    throw 'This setup script supports native 64-bit Windows only.'
+}
+if (-not [Environment]::Is64BitOperatingSystem -or
+    -not [Environment]::Is64BitProcess) {
+    throw 'Run this script from a 64-bit PowerShell process on 64-bit Windows.'
+}
+if ($GuardWarnGiB -ge $GuardLimitGiB) {
+    throw 'GuardWarnGiB must be lower than GuardLimitGiB.'
+}
+
+$requiredFiles = @(
+    $Requirements,
+    $BuildScript,
+    $InstallScript,
+    $GuardScript,
+    (Join-Path $Root 'env_windows_rocm.cmd'),
+    (Join-Path $Root 'pyproject.toml')
+)
+foreach ($path in $requiredFiles) {
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "The clone is incomplete; required file is missing: $path"
+    }
+}
+if (-not (Test-Path -LiteralPath (Join-Path $Root '.git'))) {
+    throw @"
+Git metadata is missing. Clone the repository with Git instead of downloading
+a source ZIP so versioning and editable installation have the expected history.
+"@
+}
+
+$uv = Get-RequiredApplication 'uv' `
+    'Install it from https://docs.astral.sh/uv/getting-started/installation/'
+$git = Get-RequiredApplication 'git' `
+    'Install Git for Windows, reopen PowerShell, and try again.'
+
+if (-not (Test-Path -LiteralPath $Vcvars -PathType Leaf)) {
+    throw @"
+Visual Studio 2022 Build Tools was not found at the path expected by
+env_windows_rocm.cmd:
+  $Vcvars
+Install the Desktop development with C++ workload, MSVC v143, and a Windows
+10 or 11 SDK. Reopen PowerShell after installation.
+"@
+}
+
+$amdAdapters = @()
+try {
+    $amdAdapters = @(Get-CimInstance Win32_VideoController |
+        Where-Object { $_.Name -match 'AMD|Radeon' })
+}
+catch {
+    Write-Warning "Could not query display adapters: $($_.Exception.Message)"
+}
+if ($amdAdapters.Count -eq 0) {
+    throw 'No AMD/Radeon display adapter was detected. Install the matching AMD driver first.'
+}
+
+if ($Root.Length -gt 80) {
+    Write-Warning "The clone path is long ($($Root.Length) characters). C:\AI\vllm is recommended."
+}
+
+try {
+    $system = Get-CimInstance Win32_ComputerSystem
+    $ramGiB = [math]::Round($system.TotalPhysicalMemory / 1GB, 1)
+    if ($ramGiB -lt 32) {
+        Write-Warning "Only $ramGiB GiB of system RAM was detected; 32 GiB is the practical minimum."
+    }
+}
+catch {
+    $ramGiB = 'unknown'
+    Write-Warning "Could not query system RAM: $($_.Exception.Message)"
+}
+
+try {
+    $rootItem = Get-Item -LiteralPath $Root
+    $drive = Get-PSDrive -Name $rootItem.PSDrive.Name
+    $freeGiB = [math]::Round($drive.Free / 1GB, 1)
+    if ($freeGiB -lt 25) {
+        Write-Warning "Only $freeGiB GiB is free on $($drive.Name):; builds and wheels need headroom."
+    }
+}
+catch {
+    $freeGiB = 'unknown'
+    Write-Warning "Could not query free disk space: $($_.Exception.Message)"
+}
+
+Write-Detail 'Repository' $Root
+Write-Detail 'Expected GPU' $ExpectedGpuArch
+Write-Detail 'AMD adapter' (($amdAdapters | ForEach-Object Name) -join '; ')
+Write-Detail 'System RAM GiB' ([string]$ramGiB)
+Write-Detail 'Free disk GiB' ([string]$freeGiB)
+Write-Detail 'uv' $uv
+Write-Detail 'Git' $git
+Write-Detail 'Virtual env' $Venv
+Write-Detail 'Build jobs' ([string]$MaxJobs)
+Write-Detail 'VRAM guard' "$GuardWarnGiB GiB warn / $GuardLimitGiB GiB kill"
+
+if ($PlanOnly) {
+    Write-Step 'Plan'
+    Write-Host '1. Create or reuse .venv211 with Python 3.12.'
+    Write-Host '2. Install the pinned ROCm 7.13, PyTorch 2.11, and Triton stack.'
+    Write-Host '3. Run a fail-closed guarded Torch/HIP/gfx1201 probe.'
+    Write-Host '4. Build the native C++/HIP extensions with clang-cl.'
+    Write-Host '5. Editable-install vLLM and run a guarded import/device probe.'
+    Write-Host "`nPlanOnly completed; no files, packages, GPU contexts, or builds were changed."
+    return
+}
+
+if (-not (Test-Path -LiteralPath $VenvPython -PathType Leaf)) {
+    if (Test-Path -LiteralPath $Venv) {
+        throw @"
+$Venv exists but Scripts\python.exe is missing. Refusing to overwrite an
+ambiguous environment. Rename or remove only that directory after reviewing
+its contents, then rerun this script.
+"@
+    }
+    Invoke-Native `
+        'Create Python 3.12 virtual environment' `
+        $uv `
+        @('venv', '--python', $ExpectedPython, $Venv)
+}
+else {
+    Write-Step 'Reuse existing virtual environment'
+    Write-Host $Venv
+}
+
+$pythonVersion = & $VenvPython -c `
+    'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")'
+if ($LASTEXITCODE -ne 0 -or $pythonVersion.Trim() -ne $ExpectedPython) {
+    throw "$Venv must contain Python $ExpectedPython; found '$pythonVersion'."
+}
+
+$uvPip = @('pip', 'install', '--python', $VenvPython)
+
+Invoke-Native `
+    'Install pinned AMD ROCm and PyTorch wheels' `
+    $uv `
+    ($uvPip + @(
+        '--extra-index-url', $AmdWheelIndex,
+        '--index-strategy', 'unsafe-best-match',
+        "torch==$TorchVersion",
+        "torchvision==$TorchvisionVersion",
+        "rocm[devel]==$RocmVersion"
+    ))
+
+Invoke-Native `
+    'Install pinned Triton runtime' `
+    $uv `
+    ($uvPip + @(
+        "triton-windows==$TritonVersion",
+        'winloop'
+    ))
+
+Invoke-Native `
+    'Install core vLLM Python requirements' `
+    $uv `
+    ($uvPip + @('-r', $Requirements))
+
+Invoke-Native `
+    'Install native build requirements' `
+    $uv `
+    ($uvPip + @(
+        'cmake==4.4.2',
+        'ninja',
+        'packaging>=24.2',
+        'setuptools>=77,<80',
+        'setuptools-scm>=8',
+        'setuptools-rust>=1.9',
+        'wheel',
+        'jinja2>=3.1.6'
+    ))
+
+$torchProbe = @"
+import json
+import torch
+
+if not torch.cuda.is_available():
+    raise SystemExit('Torch cannot see an AMD GPU through HIP.')
+if torch.version.hip is None:
+    raise SystemExit('This is not a ROCm/HIP PyTorch build.')
+
+properties = torch.cuda.get_device_properties(0)
+architecture = str(properties.gcnArchName)
+architecture_base = architecture.split(':', 1)[0]
+result = {
+    'torch': torch.__version__,
+    'hip': torch.version.hip,
+    'device': torch.cuda.get_device_name(0),
+    'architecture': architecture,
+}
+print(json.dumps(result, sort_keys=True))
+
+if architecture_base != '$ExpectedGpuArch':
+    raise SystemExit(
+        f'Expected $ExpectedGpuArch, but Torch reported {architecture}. '
+        'This setup script only automates the tested R9700/RDNA4 target.'
+    )
+"@
+Invoke-GuardedProbe -Name 'ROCm device verification' -PythonCode $torchProbe
+
+$previousMaxJobs = [Environment]::GetEnvironmentVariable('MAX_JOBS', 'Process')
+$previousVllmRoot = [Environment]::GetEnvironmentVariable('VLLM_ROOT', 'Process')
+try {
+    $env:MAX_JOBS = [string]$MaxJobs
+    $env:VLLM_ROOT = $Root + '\'
+
+    Invoke-Native `
+        'Build vLLM native Windows ROCm extensions' `
+        $BuildScript `
+        @()
+
+    Invoke-Native `
+        'Editable-install this vLLM fork' `
+        $InstallScript `
+        @()
+}
+finally {
+    [Environment]::SetEnvironmentVariable(
+        'MAX_JOBS',
+        $previousMaxJobs,
+        'Process'
+    )
+    [Environment]::SetEnvironmentVariable(
+        'VLLM_ROOT',
+        $previousVllmRoot,
+        'Process'
+    )
+}
+
+$installProbe = @"
+import json
+import torch
+import vllm
+
+properties = torch.cuda.get_device_properties(0)
+print(json.dumps({
+    'vllm': vllm.__version__,
+    'torch': torch.__version__,
+    'hip': torch.version.hip,
+    'device': torch.cuda.get_device_name(0),
+    'architecture': str(properties.gcnArchName),
+}, sort_keys=True))
+"@
+Invoke-GuardedProbe -Name 'Installed vLLM verification' -PythonCode $installProbe
+
+Write-Step 'Setup complete'
+Write-Host 'The tested native-Windows ROCm vLLM environment is installed.'
+Write-Host 'No model was downloaded or launched.'
+Write-Host 'Next: follow README.md -> Choosing and downloading a model, then use'
+Write-Host 'vram_guard.ps1 around every serve or benchmark command.'

--- a/tests/evals/gsm8k/configs/GLM-5.2-NVFP4-TP1-PCP4-EP.yaml
+++ b/tests/evals/gsm8k/configs/GLM-5.2-NVFP4-TP1-PCP4-EP.yaml
@@ -6,6 +6,7 @@ max_concurrency: 100
 server_args: >-
   --enforce-eager
   --max-model-len 4096
+  --max-num-batched-tokens 32768
   --safetensors-load-strategy prefetch
   --moe-backend flashinfer_cutlass
   --prefill-context-parallel-size 4

--- a/tests/evals/gsm8k/configs/GLM-5.2-NVFP4-TP2-PCP2-EP.yaml
+++ b/tests/evals/gsm8k/configs/GLM-5.2-NVFP4-TP2-PCP2-EP.yaml
@@ -6,6 +6,7 @@ max_concurrency: 100
 server_args: >-
   --enforce-eager
   --max-model-len 4096
+  --max-num-batched-tokens 32768
   --safetensors-load-strategy prefetch
   --moe-backend flashinfer_cutlass
   --tensor-parallel-size 2

--- a/tests/kernels/attention/test_merge_attn_states.py
+++ b/tests/kernels/attention/test_merge_attn_states.py
@@ -12,6 +12,9 @@ from vllm._custom_ops import (
 )
 from vllm.platforms import current_platform
 from vllm.v1.attention.ops.triton_merge_attn_states import (
+    mask_empty_context,
+)
+from vllm.v1.attention.ops.triton_merge_attn_states import (
     merge_attn_states as merge_attn_states_triton,
 )
 
@@ -71,6 +74,59 @@ HEAD_SIZES = [32, 48, 64, 96, 128, 256]
 DTYPES = [torch.float32, torch.half, torch.bfloat16]
 
 all_case_info: list[tuple] = []
+
+
+def test_mask_empty_context() -> None:
+    query_lens = torch.tensor([2] + [1] * 31 + [131, 1], dtype=torch.int32)
+    query_start_loc = torch.cat(
+        (torch.zeros(1, dtype=torch.int32), query_lens.cumsum(0))
+    ).cuda()
+    context_lens = torch.tensor([4] * 32 + [0, 3], dtype=torch.int32)
+    context_start_loc = torch.cat(
+        (torch.zeros(1, dtype=torch.int32), context_lens.cumsum(0))
+    ).cuda()
+    num_heads, num_tokens, head_dim = 4, 165, 16
+    lse = torch.randn(num_heads, num_tokens, device="cuda")
+    output = torch.randn(num_tokens, num_heads, head_dim, device="cuda")
+    # Empty-context rows carry undefined (possibly non-finite) attention output.
+    output[33:164] = float("nan")
+
+    expected_lse = lse.clone()
+    expected_lse[:, 33:164] = float("-inf")
+    expected_output = output.clone()
+    expected_output[33:164] = 0.0
+
+    mask_empty_context(lse, output, query_start_loc, context_start_loc)
+
+    torch.testing.assert_close(lse, expected_lse)
+    torch.testing.assert_close(output, expected_output)
+
+
+@pytest.mark.parametrize("merge_fn", [merge_attn_states_cuda, merge_attn_states_triton])
+@pytest.mark.parametrize("output_dtype", [torch.float32, torch.half, torch.bfloat16])
+def test_merge_attn_states_both_empty(merge_fn, output_dtype) -> None:
+    """When a token is empty on both sides (both LSE -inf), the 0/0 softmax
+    scales must not surface as NaN in the merged output."""
+    num_tokens, num_heads, head_size = 6, 8, 128
+    prefix_output = torch.zeros(
+        num_tokens, num_heads, head_size, device="cuda", dtype=output_dtype
+    )
+    prefix_lse = torch.randn(num_heads, num_tokens, device="cuda")
+    suffix_output = torch.zeros(
+        num_tokens, num_heads, head_size, device="cuda", dtype=output_dtype
+    )
+    suffix_lse = torch.randn(num_heads, num_tokens, device="cuda")
+
+    # Tokens 2 and 3 are empty on both sides (mask_empty_context already zeroed
+    # their outputs and set both LSEs to -inf).
+    empty = slice(2, 4)
+    prefix_lse[:, empty] = float("-inf")
+    suffix_lse[:, empty] = float("-inf")
+
+    output = torch.empty_like(prefix_output)
+    merge_fn(output, prefix_output, prefix_lse, suffix_output, suffix_lse)
+
+    assert not output.isnan().any()
 
 
 def generate_markdown_table():

--- a/tests/plugins_tests/test_bge_m3_sparse_io_processor_plugins.py
+++ b/tests/plugins_tests/test_bge_m3_sparse_io_processor_plugins.py
@@ -48,12 +48,12 @@ def _check_dense_embedding(data, index=0):
 def _check_sparse_embedding(data, check_tokens=False):
     expected_weights = [
         {"token_id": 32, "weight": 0.0552978515625, "token": "?"},
-        {"token_id": 70, "weight": 0.09808349609375, "token": "the"},
-        {"token_id": 83, "weight": 0.08154296875, "token": "is"},
-        {"token_id": 111, "weight": 0.11810302734375, "token": "of"},
-        {"token_id": 4865, "weight": 0.1171875, "token": "What"},
-        {"token_id": 9942, "weight": 0.292236328125, "token": "France"},
-        {"token_id": 10323, "weight": 0.2802734375, "token": "capital"},
+        {"token_id": 70, "weight": 0.09808349609375, "token": " the"},
+        {"token_id": 83, "weight": 0.08154296875, "token": " is"},
+        {"token_id": 111, "weight": 0.11810302734375, "token": " of"},
+        {"token_id": 4865, "weight": 0.1171875, "token": " What"},
+        {"token_id": 9942, "weight": 0.292236328125, "token": " France"},
+        {"token_id": 10323, "weight": 0.2802734375, "token": " capital"},
     ]
     expected_embed = {x["token_id"]: x for x in expected_weights}
 

--- a/tests/quantization/test_auto_awq.py
+++ b/tests/quantization/test_auto_awq.py
@@ -169,6 +169,66 @@ class TestAutoAWQConfigOverrideLogic:
         ), "from_config should set quant_method='awq' in full_config"
 
 
+class TestAutoAWQROCmKernelRouting:
+    """Tests for native AWQ routing into modular RDNA W4A16 kernels."""
+
+    @staticmethod
+    def _get_method(
+        monkeypatch,
+        *,
+        on_gfx1x: bool,
+        group_size: int = 128,
+        use_rdna_w4a16: bool = True,
+    ):
+        import vllm.model_executor.layers.quantization.auto_awq as auto_awq
+
+        class DummyLinear:
+            pass
+
+        monkeypatch.setattr(auto_awq, "LinearBase", DummyLinear)
+        monkeypatch.setattr(auto_awq.current_platform, "is_xpu", lambda: False)
+        monkeypatch.setattr(auto_awq.current_platform, "is_cpu", lambda: False)
+        monkeypatch.setattr(auto_awq.current_platform, "is_rocm", lambda: True)
+        monkeypatch.setattr(auto_awq.current_platform, "is_cuda", lambda: False)
+        monkeypatch.setattr("vllm.platforms.rocm.on_gfx1x", lambda: on_gfx1x)
+        monkeypatch.setattr(auto_awq, "verify_marlin_supported", lambda **kwargs: None)
+        monkeypatch.setattr(
+            auto_awq.envs,
+            "VLLM_ROCM_USE_RDNA_W4A16",
+            use_rdna_w4a16,
+        )
+
+        config = auto_awq.AutoAWQConfig(
+            weight_bits=4,
+            group_size=group_size,
+            zero_point=True,
+            lm_head_quantized=False,
+        )
+        return auto_awq, config.get_quant_method(DummyLinear(), "model.q_proj")
+
+    def test_gfx1x_uses_modular_w4a16_method(self, monkeypatch):
+        auto_awq, method = self._get_method(monkeypatch, on_gfx1x=True)
+
+        assert isinstance(method, auto_awq.AutoAWQMarlinLinearMethod)
+
+    def test_other_rocm_uses_generic_awq_fallback(self, monkeypatch):
+        auto_awq, method = self._get_method(monkeypatch, on_gfx1x=False)
+
+        assert isinstance(method, auto_awq.AutoAWQLinearMethod)
+
+    def test_unsupported_group_size_uses_generic_awq_fallback(self, monkeypatch):
+        auto_awq, method = self._get_method(monkeypatch, on_gfx1x=True, group_size=16)
+
+        assert isinstance(method, auto_awq.AutoAWQLinearMethod)
+
+    def test_disabled_rdna_w4a16_uses_generic_awq_fallback(self, monkeypatch):
+        auto_awq, method = self._get_method(
+            monkeypatch, on_gfx1x=True, use_rdna_w4a16=False
+        )
+
+        assert isinstance(method, auto_awq.AutoAWQLinearMethod)
+
+
 # =============================================================================
 # End-to-end integration tests (require GPU environment)
 # =============================================================================

--- a/tests/v1/core/test_async_scheduler.py
+++ b/tests/v1/core/test_async_scheduler.py
@@ -9,6 +9,7 @@ from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import RequestStatus
+from vllm.v1.structured_output import StructuredOutputGrammar
 from vllm.v1.utils import ConstantList
 
 from .utils import create_requests, create_scheduler
@@ -262,7 +263,7 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler = object.__new__(AsyncScheduler)
     request = create_requests(num_requests=1, num_tokens=1)[0]
     request.structured_output_request = Mock()
-    request.structured_output_request.grammar = Mock()
+    request.structured_output_request.grammar = Mock(spec=StructuredOutputGrammar)
     request.structured_output_request.grammar.accept_tokens.return_value = False
     request.status = RequestStatus.RUNNING
     request.num_computed_tokens = request.num_tokens
@@ -284,6 +285,7 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.kv_event_publisher = Mock()
     scheduler.finished_req_ids = set()
     scheduler.finished_req_ids_dict = None
+    scheduler.grammar_compile_error_reqs = set()
     scheduler.vllm_config = Mock()
     scheduler.vllm_config.model_config.enable_return_routed_experts = False
     scheduler.enable_return_routed_experts = False

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import dataclasses
+from concurrent.futures import Future
 from unittest.mock import Mock
 
 import pytest
@@ -36,7 +37,7 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
-from vllm.v1.structured_output import StructuredOutputManager
+from vllm.v1.structured_output import StructuredOutputGrammar, StructuredOutputManager
 
 from .utils import EOS_TOKEN_ID, create_requests, create_scheduler, mock_kv
 
@@ -3006,6 +3007,58 @@ def test_schedule_skip_tokenizer_init_structured_output_request():
     assert len(scheduler.skipped_waiting) == 1
 
 
+@pytest.mark.parametrize("async_grammar", [True, False])
+def test_grammar_compile_error_finishes_only_request(async_grammar: bool):
+    scheduler = create_scheduler()
+    manager = scheduler.structured_output_manager
+    manager.backend = Mock()
+    manager.backend.compile_grammar.side_effect = RuntimeError(
+        "forced FSM compilation error"
+    )
+    manager._use_async_grammar_compilation = async_grammar
+
+    sampling_params = SamplingParams(
+        max_tokens=16,
+        structured_outputs=StructuredOutputsParams(json='{"type": "object"}'),
+    )
+    sampling_params.update_from_generation_config({}, EOS_TOKEN_ID)
+    request = Request(
+        request_id="grammar-error",
+        prompt_token_ids=[0, 1],
+        sampling_params=sampling_params,
+        pooling_params=None,
+    )
+
+    manager.grammar_init(request)
+    assert request.structured_output_request is not None
+    grammar_future = request.structured_output_request._grammar
+    assert isinstance(grammar_future, Future)
+    assert isinstance(grammar_future.exception(timeout=5), RuntimeError)
+
+    scheduler.add_request(request)
+    scheduler_output = scheduler.schedule()
+    assert not scheduler_output.num_scheduled_tokens
+
+    engine_core_outputs = scheduler.update_from_output(
+        scheduler_output,
+        ModelRunnerOutput(req_ids=[], req_id_to_index={}),
+    )
+
+    assert request.status == RequestStatus.FINISHED_ERROR
+    assert request.request_id not in scheduler.requests
+    output = engine_core_outputs[0].outputs[0]
+    assert output.request_id == request.request_id
+    assert output.finish_reason == FinishReason.ERROR
+    assert output.stop_reason is None
+
+    healthy_request = create_requests(num_requests=1, req_ids=["healthy-request"])[0]
+    scheduler.add_request(healthy_request)
+    next_output = scheduler.schedule()
+    assert [req.req_id for req in next_output.scheduled_new_reqs] == [
+        healthy_request.request_id
+    ]
+
+
 def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler = object.__new__(Scheduler)
     sampling_params = SamplingParams(ignore_eos=True, max_tokens=4)
@@ -3019,7 +3072,7 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
         pooling_params=None,
     )
     request.structured_output_request = Mock()
-    request.structured_output_request.grammar = Mock()
+    request.structured_output_request.grammar = Mock(spec=StructuredOutputGrammar)
     request.structured_output_request.grammar.accept_tokens.return_value = False
     request.status = RequestStatus.RUNNING
     request.num_computed_tokens = request.num_tokens
@@ -3040,6 +3093,7 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.kv_event_publisher = Mock()
     scheduler.finished_req_ids = set()
     scheduler.finished_req_ids_dict = None
+    scheduler.grammar_compile_error_reqs = set()
     scheduler.vllm_config = Mock()
     scheduler.vllm_config.model_config.enable_return_routed_experts = False
     scheduler.enable_return_routed_experts = False

--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -11,7 +11,7 @@ import warnings
 from typing import Any
 
 import torch
-import uvloop
+from vllm.utils.async_utils import run_async
 from tqdm import tqdm
 from transformers import AutoModelForCausalLM, PreTrainedTokenizerBase
 
@@ -1185,7 +1185,7 @@ def main(args: argparse.Namespace):
     request_outputs: list[RequestOutput] | None = None
     if args.backend == "vllm":
         if args.async_engine:
-            elapsed_time = uvloop.run(
+            elapsed_time = run_async(
                 run_vllm_async(
                     requests,
                     args.n,

--- a/vllm/entrypoints/cli/launch.py
+++ b/vllm/entrypoints/cli/launch.py
@@ -4,7 +4,7 @@
 import argparse
 import signal
 
-import uvloop
+from vllm.utils.async_utils import run_async
 
 from vllm import envs
 from vllm.config import VllmConfig
@@ -54,7 +54,7 @@ class RenderSubcommand(LaunchSubcommandBase):
 
     @staticmethod
     def cmd(args: argparse.Namespace) -> None:
-        uvloop.run(run_launch_fastapi(args))
+        run_async(run_launch_fastapi(args))
 
 
 class LaunchSubcommand(CLISubcommand):

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -5,7 +5,7 @@ import argparse
 import signal
 import time
 
-import uvloop
+from vllm.utils.async_utils import run_async
 
 import vllm
 import vllm.envs as envs
@@ -55,7 +55,7 @@ class ServeSubcommand(CLISubcommand):
         if getattr(args, "grpc", False):
             from vllm.entrypoints.grpc_server import serve_grpc
 
-            uvloop.run(serve_grpc(args))
+            run_async(serve_grpc(args))
             return
 
         if args.headless:
@@ -145,7 +145,7 @@ class ServeSubcommand(CLISubcommand):
         else:
             # Single API server (this process).
             args.api_server_count = None
-            uvloop.run(run_server(args))
+            run_async(run_server(args))
 
     def validate(self, args: argparse.Namespace) -> None:
         validate_parsed_serve_args(args)

--- a/vllm/entrypoints/grpc_server.py
+++ b/vllm/entrypoints/grpc_server.py
@@ -39,7 +39,7 @@ except ImportError as e:
         "version mismatch — see the chained exception above for details."
     ) from e
 
-import uvloop
+from vllm.utils.async_utils import run_async
 
 from vllm import envs
 from vllm.engine.arg_utils import AsyncEngineArgs
@@ -190,7 +190,7 @@ def main():
 
     # Run server
     try:
-        uvloop.run(serve_grpc(args))
+        run_async(serve_grpc(args))
     except Exception as e:
         logger.exception("Server failed: %s", e)
         sys.exit(1)

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -15,7 +15,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any, cast
 
-import uvloop
+from vllm.utils.async_utils import run_async
 from fastapi import FastAPI, HTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
@@ -796,4 +796,4 @@ if __name__ == "__main__":
     args = parser.parse_args()
     validate_parsed_serve_args(args)
 
-    uvloop.run(run_server(args))
+    run_async(run_server(args))

--- a/vllm/entrypoints/openai/dp_supervisor.py
+++ b/vllm/entrypoints/openai/dp_supervisor.py
@@ -19,7 +19,7 @@ from multiprocessing.process import BaseProcess
 import aiohttp
 import psutil
 import uvicorn
-import uvloop
+from vllm.utils.async_utils import run_async
 from fastapi import FastAPI, Response
 
 import vllm.envs as envs
@@ -237,7 +237,7 @@ def _build_dp_supervisor_app(supervisor: DPSupervisor) -> FastAPI:
 def _run_python_vllm_dp_server(child_args: argparse.Namespace) -> None:
     from vllm.entrypoints.openai.api_server import run_server
 
-    uvloop.run(run_server(child_args))
+    run_async(run_server(child_args))
 
 
 def _run_rust_vllm_dp_server(child_args: argparse.Namespace) -> None:
@@ -553,4 +553,4 @@ class DPSupervisor:
 
 
 def run_dp_supervisor(args: argparse.Namespace) -> None:
-    uvloop.run(DPSupervisor(args).run())
+    run_async(DPSupervisor(args).run())

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -86,10 +86,24 @@ _maybe_set_cuda_compatibility_path()
 
 import torch
 
+# Must run before anything imports torch.distributed's submodules. Builds
+# without the c10d extension (the ROCm wheels for native Windows) get a
+# single-rank stand-in; every other build is left untouched.
+from vllm.utils.single_process_c10d import install as _install_single_process_c10d
+
+_single_process_c10d = _install_single_process_c10d()
+
 from vllm.logger import init_logger
 from vllm.utils.torch_utils import is_torch_equal, is_torch_equal_or_newer
 
 logger = init_logger(__name__)
+
+if _single_process_c10d:
+    logger.warning(
+        "This PyTorch build has no torch.distributed (c10d) extension, so "
+        "vLLM installed a single-rank stand-in. Only single-GPU execution "
+        "(tensor/pipeline/data parallel size 1) will work."
+    )
 
 # set some common config/environment variables that should be set
 # for all processes created by vllm and all processes

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -116,6 +116,7 @@ if TYPE_CHECKING:
     VLLM_FORCE_AOT_LOAD: bool = False
     VLLM_USE_MEGA_AOT_ARTIFACT: bool = False
     VLLM_USE_TRITON_AWQ: bool = False
+    VLLM_ROCM_USE_RDNA_W4A16: bool = True
     VLLM_FASTSAFETENSORS_QUEUE_SIZE: int = 0
     VLLM_TRITON_FORCE_FIRST_CONFIG: bool = False
     VLLM_ALLOW_RUNTIME_LORA_UPDATING: bool = False
@@ -1131,6 +1132,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # If set, vLLM will use Triton implementations of AWQ.
     "VLLM_USE_TRITON_AWQ": lambda: bool(int(os.getenv("VLLM_USE_TRITON_AWQ", "0"))),
+    # Use the modular hybrid W4A16 kernel for compatible native AWQ models on
+    # RDNA3/RDNA4. Set to 0 to retain the generic AutoAWQ implementation.
+    "VLLM_ROCM_USE_RDNA_W4A16": lambda: bool(
+        int(os.getenv("VLLM_ROCM_USE_RDNA_W4A16", "1"))
+    ),
     # If set, monkey-patch triton.runtime.autotuner.Autotuner.run to skip
     # benchmarking and select the first valid config (walking past invalid
     # ones). Used to eliminate autotuning variability when measuring kernel

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -277,6 +277,7 @@ from vllm.v1.attention.backends.utils import (
 from vllm.v1.attention.ops.common import cp_lse_ag_out_ar, cp_lse_ag_out_rs
 from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
+from vllm.v1.attention.ops.triton_merge_attn_states import mask_empty_context
 from vllm.v1.attention.selector import get_attn_backend
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
@@ -1342,6 +1343,7 @@ class MLACommonPrefillMetadata:
         workspace: torch.Tensor
         token_to_seq: torch.Tensor
         chunk_total_token: list[int]
+        has_empty_context: list[bool]
 
         # for mla DCP
         padded_local_chunk_seq_lens: list[list[int]] | None = None
@@ -1551,6 +1553,7 @@ def build_mla_chunked_context_metadata(
     )
     chunk_seq_lens = chunk_ends - chunk_starts
     chunk_seq_lens.clamp_(min=0)
+    has_empty_context = torch.any(chunk_seq_lens == 0, dim=1).tolist()
 
     cu_seq_lens_cpu = torch.zeros(
         num_chunks, num_prefills + 1, dtype=torch.int32, pin_memory=True
@@ -1629,6 +1632,7 @@ def build_mla_chunked_context_metadata(
             token_to_seq=token_to_seq_cpu.to(device, non_blocking=True),
             chunk_total_token=chunk_total_token.tolist(),
             workspace=chunked_prefill_workspace,
+            has_empty_context=has_empty_context,
             prefill_tokens_with_context=prefill_tokens_with_context,
             padded_local_chunk_seq_lens=padded_local_chunk_seq_lens.tolist(),
             local_context_lens_allranks=local_context_lens_allranks.tolist(),
@@ -1651,6 +1655,7 @@ def build_mla_chunked_context_metadata(
             token_to_seq=token_to_seq_cpu.to(device, non_blocking=True),
             chunk_total_token=chunk_total_token,
             workspace=chunked_prefill_workspace,
+            has_empty_context=has_empty_context,
             prefill_tokens_with_context=prefill_tokens_with_context,
         )
 
@@ -2238,6 +2243,13 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
                     v=v,
                 )
             )
+            if prefill_metadata.chunked_context.has_empty_context[i]:
+                mask_empty_context(
+                    attn_softmax_lse,
+                    attn_output,
+                    prefill_metadata.query_start_loc,
+                    prefill_metadata.chunked_context.cu_seq_lens[i],
+                )
 
             if output is None:
                 output = attn_output
@@ -2388,6 +2400,13 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
                     v=v,
                 )
             )
+            if prefill_metadata.chunked_context.has_empty_context[i]:
+                mask_empty_context(
+                    attn_softmax_lse,
+                    attn_output,
+                    prefill_metadata.query_start_loc,
+                    prefill_metadata.chunked_context.cu_seq_lens[i],
+                )
 
             if output is None:
                 output = attn_output

--- a/vllm/model_executor/layers/quantization/auto_awq.py
+++ b/vllm/model_executor/layers/quantization/auto_awq.py
@@ -305,6 +305,23 @@ class AutoAWQConfig(QuantizationConfig):
             if current_platform.is_cpu():
                 return AutoAWQMarlinLinearMethod(self)
 
+            # RDNA3/RDNA4 have a modular hybrid W4A16 kernel: a HIP skinny
+            # GEMM for decode and a tuned Triton GEMM for larger batches.
+            # Route compatible native AWQ checkpoints through the modular
+            # kernel selector so they can use that path after AWQ packing is
+            # converted to the standard MPLinearKernel format below. Keep the
+            # generic AWQ implementation as the fallback for other ROCm GPUs.
+            if current_platform.is_rocm():
+                from vllm.platforms.rocm import on_gfx1x
+
+                if (
+                    envs.VLLM_ROCM_USE_RDNA_W4A16
+                    and on_gfx1x()
+                    and self.weight_bits == 4
+                    and self.group_size in (32, 64, 128)
+                ):
+                    return AutoAWQMarlinLinearMethod(self)
+
             # Check if Marlin is supported and not using batch invariant mode
             # (Marlin kernels are not batch invariant)
             use_marlin = (

--- a/vllm/model_executor/warmup/deep_gemm_warmup.py
+++ b/vllm/model_executor/warmup/deep_gemm_warmup.py
@@ -133,6 +133,18 @@ def _extract_data_from_fused_moe_module(
     return w13, w13_s, w2, w2_s, num_topk
 
 
+def _is_deep_gemm_backed_kernel(fp8_linear: object) -> bool:
+    """
+    Return True if the selected linear kernel dispatches to DeepGEMM, either
+    directly or as the fallback branch of a dynamic wrapper.
+    """
+    if isinstance(fp8_linear, DeepGemmFp8BlockScaledMMKernel):
+        return True
+    return isinstance(
+        getattr(fp8_linear, "fallback", None), DeepGemmFp8BlockScaledMMKernel
+    )
+
+
 def _fp8_linear_may_use_deep_gemm(module: torch.nn.Module) -> bool:
     """
     Return True if the input module/layer could be processed with DeepGEMM.
@@ -147,10 +159,8 @@ def _fp8_linear_may_use_deep_gemm(module: torch.nn.Module) -> bool:
     ):
         return False
 
-    if not isinstance(
-        getattr(module.quant_method, "fp8_linear", None),
-        DeepGemmFp8BlockScaledMMKernel,
-    ):
+    fp8_linear = getattr(module.quant_method, "fp8_linear", None)
+    if not _is_deep_gemm_backed_kernel(fp8_linear):
         return False
 
     block_size = get_mk_alignment_for_contiguous_layout()[0]

--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -125,6 +125,18 @@ def rocm_platform_plugin() -> str | None:
     except Exception as e:
         logger.debug("ROCm platform is not available because: %s", str(e))
 
+    if not is_rocm:
+        # amdsmi has no Windows build, so fall back to asking torch whether it
+        # is a HIP build that can see a device.
+        try:
+            import torch
+
+            if torch.version.hip is not None and torch.cuda.device_count() > 0:
+                is_rocm = True
+                logger.debug("Confirmed ROCm platform is available via torch.")
+        except Exception as e:
+            logger.debug("ROCm platform is not available via torch because: %s", str(e))
+
     return "vllm.platforms.rocm.RocmPlatform" if is_rocm else None
 
 

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -290,7 +290,8 @@ class CudaPlatformBase(Platform):
             # kernel with limited pinned memory support for CUDA.
             version = _get_wsl_kernel_version()
             if version is None or version < (4, 19, 121):
-                logger.warning_once(
+                # warning_once() causes a circular import on WSL, see #48397.
+                logger.warning(
                     "Using 'pin_memory=False' as WSL is detected and the "
                     "WSL2 kernel version is below 4.19.121. This may slow "
                     "down performance. Please run `wsl --update`."

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -991,7 +991,8 @@ class Platform:
             # Pinned memory support under WSL depends on the vendor and driver
             # version. Conservative default: return False. Platform subclasses
             # that can verify support (e.g. CudaPlatformBase) override this.
-            logger.warning_once(
+            # warning_once() causes a circular import on WSL, see #48397.
+            logger.warning(
                 "Using 'pin_memory=False' as WSL is detected. "
                 "This may slow down performance."
             )

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -37,8 +37,15 @@ try:
         amdsmi_topo_get_link_type,
         amdsmi_topo_get_numa_node_number,
     )
+
+    AMDSMI_AVAILABLE = True
 except ImportError as e:
     logger.warning("Failed to import from amdsmi with %r", e)
+    # amdsmi has no Windows build. Everything that queries it has a torch
+    # fallback; this flag is what routes callers there instead of tripping
+    # over the missing names.
+    AMDSMI_AVAILABLE = False
+    AmdSmiException = Exception
 
 try:
     import vllm._C  # noqa: F401
@@ -154,6 +161,8 @@ _sync_hip_cuda_env_vars()
 def with_amdsmi_context(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):
+        if not AMDSMI_AVAILABLE:
+            raise RuntimeError("amdsmi is not available on this platform")
         amdsmi_init()
         try:
             return fn(*args, **kwargs)
@@ -194,7 +203,11 @@ def _get_gcn_arch() -> str:
         return _query_gcn_arch_from_amdsmi()
     except Exception as e:
         logger.debug("Failed to get GCN arch via amdsmi: %s", e)
-        logger.warning_once(
+        # Plain warning, not warning_once: this runs at module scope, and
+        # warning_once consults the distributed state, which imports back into
+        # vllm.platforms before it has finished initializing. Once-ness is
+        # already guaranteed here -- _GCN_ARCH is resolved a single time.
+        logger.warning(
             "Failed to get GCN arch via amdsmi, falling back to torch.cuda. "
             "This will initialize CUDA and may cause "
             "issues if CUDA_VISIBLE_DEVICES is not set yet."
@@ -710,8 +723,18 @@ class RocmPlatform(Platform):
         return DeviceCapability(major=major, minor=minor)
 
     @classmethod
-    @with_amdsmi_context
     def is_fully_connected(cls, physical_device_ids: list[int]) -> bool:
+        try:
+            return cls._is_fully_connected_from_amdsmi(physical_device_ids)
+        except Exception as e:
+            logger.debug("Failed to query xgmi topology via amdsmi: %s", e)
+        # A single GPU is trivially fully connected; without topology data we
+        # cannot claim anything stronger.
+        return len(physical_device_ids) <= 1
+
+    @classmethod
+    @with_amdsmi_context
+    def _is_fully_connected_from_amdsmi(cls, physical_device_ids: list[int]) -> bool:
         """
         Query if the set of gpus are fully connected by xgmi (1 hop)
         """
@@ -730,9 +753,17 @@ class RocmPlatform(Platform):
         return True
 
     @classmethod
+    def get_device_name(cls, device_id: int = 0) -> str:
+        try:
+            return cls._get_device_name_from_amdsmi(device_id)
+        except Exception as e:
+            logger.debug("Failed to get device name via amdsmi: %s", e)
+        return torch.cuda.get_device_properties(device_id).name
+
+    @classmethod
     @with_amdsmi_context
     @lru_cache(maxsize=8)
-    def get_device_name(cls, device_id: int = 0) -> str:
+    def _get_device_name_from_amdsmi(cls, device_id: int = 0) -> str:
         physical_device_id = cls.device_id_to_physical_device_id(device_id)
         handle = amdsmi_get_processor_handles()[physical_device_id]
         asic_info = amdsmi_get_gpu_asic_info(handle)
@@ -742,8 +773,16 @@ class RocmPlatform(Platform):
         return asic_info["market_name"]
 
     @classmethod
-    @with_amdsmi_context
     def get_device_uuid(cls, device_id: int = 0) -> str:
+        try:
+            return cls._get_device_uuid_from_amdsmi(device_id)
+        except Exception as e:
+            logger.debug("Failed to get device uuid via amdsmi: %s", e)
+        return ""
+
+    @classmethod
+    @with_amdsmi_context
+    def _get_device_uuid_from_amdsmi(cls, device_id: int = 0) -> str:
         try:
             device = amdsmi_get_processor_handles()[device_id]
         except AmdSmiException as error:
@@ -1039,8 +1078,16 @@ class RocmPlatform(Platform):
         )
 
     @classmethod
-    @with_amdsmi_context
     def get_all_device_numa_nodes(cls) -> list[int] | None:
+        try:
+            return cls._get_all_device_numa_nodes_from_amdsmi()
+        except Exception as e:
+            logger.debug("Failed to get NUMA nodes via amdsmi: %s", e)
+        return None
+
+    @classmethod
+    @with_amdsmi_context
+    def _get_all_device_numa_nodes_from_amdsmi(cls) -> list[int] | None:
         """Get NUMA nodes for all visible GPU devices."""
         try:
             handles = amdsmi_get_processor_handles()

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -72,6 +72,7 @@ class LazyConfigDict(dict):
 _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
     afmoe="AfmoeConfig",
     arctic="ArcticConfig",
+    axk1="AXK1Config",
     bagel="BagelConfig",
     umm="CheersConfig",
     chatglm="ChatGLMConfig",

--- a/vllm/transformers_utils/configs/AXK1.py
+++ b/vllm/transformers_utils/configs/AXK1.py
@@ -114,7 +114,7 @@ class AXK1Config(PretrainedConfig):
             The dropout ratio for the attention probabilities.
     """
 
-    model_type = "AXK1"
+    model_type = "axk1"
     keys_to_ignore_at_inference = ["past_key_values"]
 
     def __init__(

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -261,7 +261,7 @@ class ModelArchConfigConvertorBase:
         if not hasattr(self.hf_text_config, "model_type"):
             return False
         elif self.hf_text_config.model_type in (
-            "AXK1",
+            "axk1",
             "deepseek_v2",
             "deepseek_v3",
             "deepseek_v32",
@@ -290,7 +290,7 @@ class ModelArchConfigConvertorBase:
             return (
                 self.hf_text_config.model.model_type
                 in (
-                    "AXK1",
+                    "axk1",
                     "deepseek_v2",
                     "deepseek_v3",
                     "deepseek_v32",

--- a/vllm/utils/async_utils.py
+++ b/vllm/utils/async_utils.py
@@ -20,6 +20,25 @@ P = ParamSpec("P")
 T = TypeVar("T")
 
 
+def _resolve_event_loop_runner() -> Callable[..., object]:
+    """Pick the fastest available drop-in for ``asyncio.run``.
+
+    uvloop is POSIX-only; winloop is the same libuv loop packaged for Windows.
+    Plain asyncio is the last resort so a missing accelerator degrades
+    performance rather than breaking startup.
+    """
+    for name in ("uvloop", "winloop"):
+        try:
+            return __import__(name).run
+        except ImportError:
+            continue
+    return asyncio.run
+
+
+run_async = _resolve_event_loop_runner()
+"""Run a coroutine to completion on the fastest event loop available."""
+
+
 def cancel_task_threadsafe(task: Task):
     if task and not task.done():
         run_in_loop(task.get_loop(), task.cancel)

--- a/vllm/utils/network_utils.py
+++ b/vllm/utils/network_utils.py
@@ -139,6 +139,11 @@ def get_tcp_uri(ip: str, port: int) -> str:
 
 
 def get_open_zmq_ipc_path() -> str:
+    if sys.platform == "win32":
+        # ZeroMQ's ipc:// transport is backed by a Unix domain socket and is
+        # not implemented on Windows. Loopback TCP is the portable equivalent;
+        # the traffic never leaves the host either way.
+        return f"tcp://127.0.0.1:{get_open_port()}"
     base_rpc_path = envs.VLLM_RPC_BASE_PATH
     return f"ipc://{base_rpc_path}/{uuid4()}"
 

--- a/vllm/utils/single_process_c10d.py
+++ b/vllm/utils/single_process_c10d.py
@@ -1,0 +1,906 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""A single-rank stand-in for ``torch.distributed``.
+
+Some PyTorch builds ship without the c10d extension. The AMD ROCm wheels for
+native Windows are the motivating case: they are compiled with
+``USE_DISTRIBUTED=0`` / ``USE_GLOO=OFF``, so ``torch._C._distributed_c10d``
+does not exist, ``torch.distributed.is_available()`` is False, and importing
+``torch.distributed._functional_collectives`` -- which ``parallel_state`` does
+at module scope -- raises ``ModuleNotFoundError``. vLLM cannot be imported at
+all on such a build.
+
+vLLM only needs real collectives when a group spans more than one rank, and
+``GroupCoordinator`` already short-circuits every collective it owns when
+``world_size == 1``. This module fills in the gap for exactly that case: it
+installs an in-process implementation where every group has a single rank, so
+each collective is the identity. Anything that genuinely requires a peer raises
+``RuntimeError`` rather than silently returning wrong data.
+
+``install()`` is a no-op when torch has a real ``torch.distributed``.
+"""
+
+import sys
+import types
+from datetime import timedelta
+from enum import Enum
+from typing import Any
+
+import torch
+
+_WORLD_SIZE = 1
+_RANK = 0
+
+
+_installed = False
+
+
+def is_needed() -> bool:
+    """True when this torch build has no usable ``torch.distributed``.
+
+    ``torch.distributed.is_available()`` is deliberately left reporting False
+    even after install: torch's own internals (dynamo's trace rules, FSDP) key
+    off it to decide whether to import distributed-only modules, and those
+    really are unavailable. Only vLLM is meant to see the stand-in.
+    """
+    return not torch.distributed.is_available()
+
+
+class ReduceOp(Enum):
+    SUM = 0
+    AVG = 1
+    PRODUCT = 2
+    MIN = 3
+    MAX = 4
+    BAND = 5
+    BOR = 6
+    BXOR = 7
+    PREMUL_SUM = 8
+
+
+class Backend(str):
+    GLOO = "gloo"
+    NCCL = "nccl"
+    MPI = "mpi"
+    UNDEFINED = "undefined"
+
+    def __new__(cls, name: str):
+        return super().__new__(cls, name.lower())
+
+
+class Work:
+    """A collective that has already completed, because there was nothing
+    to exchange."""
+
+    def wait(self, timeout: timedelta | None = None) -> bool:
+        return True
+
+    def is_completed(self) -> bool:
+        return True
+
+    def is_success(self) -> bool:
+        return True
+
+    def get_future(self) -> Any:
+        future: torch.futures.Future = torch.futures.Future()
+        future.set_result(None)
+        return future
+
+
+class ProcessGroup:
+    """A group of exactly one rank."""
+
+    class BackendType(Enum):
+        UNDEFINED = 0
+        GLOO = 1
+        NCCL = 2
+        CUSTOM = 3
+
+    class Options:
+        def __init__(self, backend: str = "gloo", timeout=None):
+            self.backend = backend
+            self._timeout = timeout
+
+    def __init__(self, name: str = "default", backend: str = "gloo"):
+        self.group_name = name
+        self._backend = backend
+        self.bound_device_id: torch.device | None = None
+
+    def size(self) -> int:
+        return _WORLD_SIZE
+
+    def rank(self) -> int:
+        return _RANK
+
+    def name(self) -> str:
+        return self.group_name
+
+    def _get_backend(self, device: torch.device | None = None) -> "ProcessGroup":
+        # vLLM only reaches for the backend object to poke at its options; the
+        # group itself is a close enough stand-in for a single rank.
+        return self
+
+    def _get_backend_name(self) -> str:
+        return self._backend
+
+    def _set_default_backend(self, backend_type) -> None:
+        pass
+
+    def _register_backend(self, device, backend_type, backend_class) -> None:
+        pass
+
+    def _set_sequence_number_for_group(self) -> None:
+        pass
+
+    def __repr__(self) -> str:
+        return f"<single-rank ProcessGroup {self.group_name!r} ({self._backend})>"
+
+
+class ProcessGroupGloo(ProcessGroup):
+    """What ``stateless_init_torch_distributed_process_group`` constructs."""
+
+    def __init__(self, store=None, rank: int = 0, size: int = 1, timeout=None):
+        if size != 1 or rank != 0:
+            _no_peer(f"ProcessGroupGloo(rank={rank}, size={size})")
+        super().__init__("gloo", "gloo")
+
+
+class Store:
+    """An in-process key/value store. Only one rank ever reads it."""
+
+    def __init__(self, *args, **kwargs):
+        self._data: dict[str, bytes] = {}
+
+    def set(self, key: str, value: Any) -> None:
+        self._data[key] = value if isinstance(value, bytes) else str(value).encode()
+
+    def get(self, key: str) -> bytes:
+        if key not in self._data:
+            raise RuntimeError(f"Key {key!r} not set in single-rank store")
+        return self._data[key]
+
+    def add(self, key: str, amount: int) -> int:
+        total = int(self._data.get(key, b"0")) + amount
+        self._data[key] = str(total).encode()
+        return total
+
+    def delete_key(self, key: str) -> bool:
+        return self._data.pop(key, None) is not None
+
+    def wait(self, keys, timeout: timedelta | None = None) -> None:
+        missing = [k for k in keys if k not in self._data]
+        if missing:
+            raise RuntimeError(f"Keys {missing} will never be set by a peer rank")
+
+    def num_keys(self) -> int:
+        return len(self._data)
+
+    def set_timeout(self, timeout: timedelta) -> None:
+        pass
+
+
+class PrefixStore(Store):
+    def __init__(self, prefix: str, store: Store | None = None, *args, **kwargs):
+        super().__init__()
+        self.prefix = prefix
+        self.underlying_store = store
+
+
+class DistError(RuntimeError):
+    pass
+
+
+class DistBackendError(DistError):
+    pass
+
+
+class DistNetworkError(DistError):
+    pass
+
+
+class DistStoreError(DistError):
+    pass
+
+
+_WORLD: ProcessGroup | None = None
+
+
+class _GroupMember:
+    WORLD: ProcessGroup | None = None
+    NON_GROUP_MEMBER = -100
+
+
+class _World:
+    """Stands in for ``distributed_c10d._world``, the global group registry."""
+
+    def __init__(self):
+        self.pg_map: dict[ProcessGroup, Any] = {}
+        self.pg_names: dict[ProcessGroup, str] = {}
+        self.pg_group_ranks: dict[ProcessGroup, dict[int, int]] = {}
+        self.pg_backend_config: dict[ProcessGroup, str] = {}
+        self.group_count = 0
+
+    @property
+    def default_pg(self) -> ProcessGroup | None:
+        return _WORLD
+
+    @property
+    def WORLD(self) -> ProcessGroup | None:
+        return _WORLD
+
+
+_world = _World()
+
+
+def _get_default_timeout(backend=None) -> timedelta:
+    return timedelta(minutes=10)
+
+
+def _get_default_group() -> ProcessGroup:
+    return _resolve(None)
+
+
+def _register_process_group(group_name: str, pg: ProcessGroup) -> None:
+    _world.pg_names[pg] = group_name
+
+
+def _unregister_process_group(group_name: str) -> None:
+    for pg, name in list(_world.pg_names.items()):
+        if name == group_name:
+            del _world.pg_names[pg]
+
+
+def _resolve_process_group(group_name: str) -> ProcessGroup:
+    for pg, name in _world.pg_names.items():
+        if name == group_name:
+            return pg
+    raise RuntimeError(f"No process group registered as {group_name!r}")
+
+
+def _no_peer(op: str):
+    raise RuntimeError(
+        f"torch.distributed.{op} needs at least one peer rank, but this "
+        "PyTorch build has no c10d extension so vLLM is running against a "
+        "single-rank stand-in. Only single-GPU (TP=PP=DP=1) execution is "
+        "supported here."
+    )
+
+
+def _resolve(group) -> ProcessGroup:
+    if group is None:
+        if _WORLD is None:
+            raise RuntimeError("Default process group has not been initialized")
+        return _WORLD
+    return group
+
+
+# --- lifecycle -------------------------------------------------------------
+
+
+def is_initialized() -> bool:
+    return _WORLD is not None
+
+
+def init_process_group(
+    backend: str | None = None,
+    init_method: str | None = None,
+    timeout: timedelta | None = None,
+    world_size: int = -1,
+    rank: int = -1,
+    store: Store | None = None,
+    group_name: str = "",
+    pg_options: Any = None,
+    device_id: torch.device | None = None,
+    **kwargs,
+) -> None:
+    global _WORLD
+    if world_size not in (-1, 1) or rank not in (-1, 0):
+        _no_peer(f"init_process_group(world_size={world_size}, rank={rank})")
+    if _WORLD is not None:
+        raise RuntimeError("Default process group is already initialized")
+    _WORLD = ProcessGroup("default", str(backend or "gloo"))
+    _WORLD.bound_device_id = device_id
+    _GroupMember.WORLD = _WORLD
+    # Presence in pg_map is how callers tell a stateful group from one built
+    # by vLLM's stateless_init_torch_distributed_process_group.
+    _world.pg_map[_WORLD] = (str(backend or "gloo"), store)
+    _world.pg_names[_WORLD] = "default"
+
+
+def destroy_process_group(group: ProcessGroup | None = None) -> None:
+    global _WORLD
+    if group is None or group is _WORLD:
+        _WORLD = None
+        _GroupMember.WORLD = None
+
+
+def new_group(
+    ranks: list[int] | None = None,
+    timeout: timedelta | None = None,
+    backend: str | None = None,
+    pg_options: Any = None,
+    use_local_synchronization: bool = False,
+    group_desc: str | None = None,
+    device_id: torch.device | None = None,
+    **kwargs,
+) -> ProcessGroup:
+    if ranks is not None and list(ranks) not in ([], [0]):
+        _no_peer(f"new_group(ranks={list(ranks)})")
+    _world.group_count += 1
+    name = group_desc or f"group{_world.group_count}"
+    group = ProcessGroup(name, str(backend or "gloo"))
+    group.bound_device_id = device_id
+    _world.pg_map[group] = (group._backend, None)
+    _world.pg_names[group] = name
+    return group
+
+
+def split_group(
+    parent_pg: ProcessGroup | None = None,
+    split_ranks: list[list[int]] | None = None,
+    timeout: timedelta | None = None,
+    pg_options: Any = None,
+    group_desc: str | None = None,
+    **kwargs,
+) -> ProcessGroup:
+    return new_group(group_desc=group_desc, **kwargs)
+
+
+def new_subgroups_by_enumeration(*args, **kwargs):
+    return new_group(), [new_group()]
+
+
+def rendezvous(url: str, rank: int = -1, world_size: int = -1, **kwargs):
+    yield Store(), 0, 1
+
+
+# --- introspection ---------------------------------------------------------
+
+
+def get_rank(group: ProcessGroup | None = None) -> int:
+    return _RANK
+
+
+def get_world_size(group: ProcessGroup | None = None) -> int:
+    return _WORLD_SIZE
+
+
+def get_backend(group: ProcessGroup | None = None) -> str:
+    return _resolve(group)._get_backend_name()
+
+
+def get_process_group_ranks(group: ProcessGroup | None = None) -> list[int]:
+    return [_RANK]
+
+
+def get_group_rank(group: ProcessGroup, global_rank: int) -> int:
+    if global_rank != _RANK:
+        _no_peer(f"get_group_rank(global_rank={global_rank})")
+    return _RANK
+
+
+def get_global_rank(group: ProcessGroup, group_rank: int) -> int:
+    if group_rank != _RANK:
+        _no_peer(f"get_global_rank(group_rank={group_rank})")
+    return _RANK
+
+
+def is_backend_available(backend: str) -> bool:
+    return str(backend).lower() == "gloo"
+
+
+def is_gloo_available() -> bool:
+    return True
+
+
+def is_nccl_available() -> bool:
+    return False
+
+
+def is_mpi_available() -> bool:
+    return False
+
+
+def is_ucc_available() -> bool:
+    return False
+
+
+def is_xccl_available() -> bool:
+    return False
+
+
+def is_torchelastic_launched() -> bool:
+    return False
+
+
+def supports_complex(reduce_op: ReduceOp) -> bool:
+    return True
+
+
+# --- collectives (identity, because there is exactly one rank) -------------
+
+
+def _done(async_op: bool):
+    return Work() if async_op else None
+
+
+def barrier(group=None, async_op=False, device_ids=None, **kwargs):
+    return _done(async_op)
+
+
+def monitored_barrier(group=None, timeout=None, wait_all_ranks=False):
+    return None
+
+
+def all_reduce(tensor, op=ReduceOp.SUM, group=None, async_op=False, **kwargs):
+    return _done(async_op)
+
+
+def reduce(tensor, dst, op=ReduceOp.SUM, group=None, async_op=False, **kwargs):
+    return _done(async_op)
+
+
+def broadcast(tensor, src=0, group=None, async_op=False, **kwargs):
+    return _done(async_op)
+
+
+def all_gather(tensor_list, tensor, group=None, async_op=False, **kwargs):
+    tensor_list[0].copy_(tensor)
+    return _done(async_op)
+
+
+def all_gather_into_tensor(output_tensor, input_tensor, group=None, async_op=False):
+    output_tensor.copy_(input_tensor.reshape(output_tensor.shape))
+    return _done(async_op)
+
+
+def gather(tensor, gather_list=None, dst=0, group=None, async_op=False, **kwargs):
+    if gather_list is not None:
+        gather_list[0].copy_(tensor)
+    return _done(async_op)
+
+
+def scatter(tensor, scatter_list=None, src=0, group=None, async_op=False, **kwargs):
+    if scatter_list is not None:
+        tensor.copy_(scatter_list[0])
+    return _done(async_op)
+
+
+def reduce_scatter(output, input_list, op=ReduceOp.SUM, group=None, async_op=False):
+    output.copy_(input_list[0])
+    return _done(async_op)
+
+
+def reduce_scatter_tensor(
+    output, input, op=ReduceOp.SUM, group=None, async_op=False, **kwargs
+):
+    output.copy_(input.reshape(output.shape))
+    return _done(async_op)
+
+
+def all_to_all_single(
+    output,
+    input,
+    output_split_sizes=None,
+    input_split_sizes=None,
+    group=None,
+    async_op=False,
+):
+    output.copy_(input.reshape(output.shape))
+    return _done(async_op)
+
+
+def all_to_all(output_tensor_list, input_tensor_list, group=None, async_op=False):
+    output_tensor_list[0].copy_(input_tensor_list[0])
+    return _done(async_op)
+
+
+def all_gather_object(object_list, obj, group=None):
+    object_list[0] = obj
+
+
+def gather_object(obj, object_gather_list=None, dst=0, group=None):
+    if object_gather_list is not None:
+        object_gather_list[0] = obj
+
+
+def scatter_object_list(
+    scatter_object_output_list, scatter_object_input_list=None, src=0, group=None
+):
+    if scatter_object_input_list is not None:
+        scatter_object_output_list[0] = scatter_object_input_list[0]
+
+
+def broadcast_object_list(object_list, src=0, group=None, device=None):
+    return None
+
+
+# --- point-to-point (impossible with one rank) -----------------------------
+
+
+def send(tensor, dst=None, group=None, tag=0, **kwargs):
+    _no_peer("send")
+
+
+def recv(tensor, src=None, group=None, tag=0, **kwargs):
+    _no_peer("recv")
+
+
+def isend(tensor, dst=None, group=None, tag=0, **kwargs):
+    _no_peer("isend")
+
+
+def irecv(tensor, src=None, group=None, tag=0, **kwargs):
+    _no_peer("irecv")
+
+
+def batch_isend_irecv(p2p_op_list):
+    _no_peer("batch_isend_irecv")
+
+
+class P2POp:
+    def __init__(self, op, tensor, peer, group=None, tag=0):
+        _no_peer("P2POp")
+
+
+# --- submodule payloads ----------------------------------------------------
+
+
+def _build_functional_collectives() -> types.ModuleType:
+    """``torch.distributed._functional_collectives`` -- the async-tensor API.
+
+    With one rank every collective is the identity and nothing is ever in
+    flight, so the "async" tensors are just the inputs.
+    """
+    mod = types.ModuleType("torch.distributed._functional_collectives")
+
+    def wait_tensor(tensor):
+        return tensor
+
+    def all_reduce_(tensor, reduceOp="sum", group=None, tag=""):
+        return tensor
+
+    def all_gather_tensor(tensor, gather_dim=0, group=None, tag=""):
+        return tensor
+
+    def reduce_scatter_tensor_(tensor, reduceOp="sum", scatter_dim=0, group=None, tag=""):
+        return tensor
+
+    def all_to_all_single_(output, input_, *args, **kwargs):
+        return output
+
+    def broadcast_(tensor, src=0, group=None, tag=""):
+        return tensor
+
+    mod.wait_tensor = wait_tensor
+    mod.all_reduce = all_reduce_
+    mod.all_gather_tensor = all_gather_tensor
+    mod.all_gather_into_tensor = all_gather_tensor
+    mod.reduce_scatter_tensor = reduce_scatter_tensor_
+    mod.all_to_all_single = all_to_all_single_
+    mod.broadcast = broadcast_
+    mod.AsyncCollectiveTensor = torch.Tensor
+    return mod
+
+
+def _build_symmetric_memory() -> types.ModuleType:
+    """``torch.distributed._symmetric_memory`` -- NVLink/xGMI peer buffers.
+
+    There is no peer to share memory with, so the module reports itself
+    unavailable and vLLM takes its ordinary paths.
+    """
+    mod = types.ModuleType("torch.distributed._symmetric_memory")
+
+    def unavailable(*args, **kwargs):
+        raise RuntimeError(
+            "Symmetric memory is not available without torch.distributed"
+        )
+
+    mod.enable_symm_mem_for_group = unavailable
+    mod.empty = unavailable
+    mod.rendezvous = unavailable
+    mod.is_nvshmem_available = lambda: False
+    mod.get_symm_mem_workspace = unavailable
+    mod._fused_scaled_matmul_reduce_scatter_impl = unavailable
+    mod._fused_all_gather_matmul_impl = unavailable
+    mod._pipelined_multi_all_gather_and_consume = unavailable
+    return mod
+
+
+def _build_distributed_c10d(dist: types.ModuleType) -> types.ModuleType:
+    """``torch.distributed.distributed_c10d`` -- re-exports of the above.
+
+    Callers reach into this module for the same names the package exposes, so
+    it is a thin view over what we just installed.
+    """
+    mod = types.ModuleType("torch.distributed.distributed_c10d")
+    for name in dir(dist):
+        if not name.startswith("__"):
+            setattr(mod, name, getattr(dist, name))
+    mod.GroupMember = _GroupMember
+    return mod
+
+
+def _build_dtensor_modules() -> dict[str, types.ModuleType]:
+    """``torch.distributed.tensor`` and friends -- the DTensor subsystem.
+
+    vLLM never builds a DTensor, but transformers imports the API at module
+    scope guarded only by ``is_torch_available()``, so the names have to
+    resolve. They are deliberately inert: sharding a tensor across one rank is
+    never something we should be asked to do, and doing it silently wrong would
+    be worse than failing.
+    """
+
+    class Placement:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class Shard(Placement):
+        def __init__(self, dim: int = 0):
+            self.dim = dim
+
+        def local_shard_size_and_offset(self, *args, **kwargs):
+            _no_peer("Shard.local_shard_size_and_offset")
+
+    class Replicate(Placement):
+        pass
+
+    class Partial(Placement):
+        def __init__(self, reduce_op: str = "sum"):
+            self.reduce_op = reduce_op
+
+    class DeviceMesh:
+        def __init__(self, device_type: str = "cpu", mesh=None, **kwargs):
+            self.device_type = device_type
+            self.mesh = mesh
+
+        def size(self, dim: int | None = None) -> int:
+            return _WORLD_SIZE
+
+        def get_rank(self) -> int:
+            return _RANK
+
+    class DTensor(torch.Tensor):
+        """Nothing is ever an instance of this; it exists for isinstance()."""
+
+        @staticmethod
+        def from_local(*args, **kwargs):
+            _no_peer("DTensor.from_local")
+
+    def init_device_mesh(device_type, mesh_shape, **kwargs):
+        if tuple(mesh_shape) not in ((), (1,)):
+            _no_peer(f"init_device_mesh(mesh_shape={tuple(mesh_shape)})")
+        return DeviceMesh(device_type, mesh_shape)
+
+    def distribute_tensor(*args, **kwargs):
+        _no_peer("distribute_tensor")
+
+    def compute_local_shape_and_global_offset(*args, **kwargs):
+        _no_peer("compute_local_shape_and_global_offset")
+
+    tensor = types.ModuleType("torch.distributed.tensor")
+    tensor.DTensor = DTensor
+    tensor.DeviceMesh = DeviceMesh
+    tensor.Shard = Shard
+    tensor.Replicate = Replicate
+    tensor.Partial = Partial
+    tensor.Placement = Placement
+    tensor.init_device_mesh = init_device_mesh
+    tensor.distribute_tensor = distribute_tensor
+    tensor.distribute_module = distribute_tensor
+    tensor.zeros = distribute_tensor
+    tensor.empty = distribute_tensor
+    tensor.ones = distribute_tensor
+
+    placement_types = types.ModuleType("torch.distributed.tensor.placement_types")
+    placement_types.Placement = Placement
+    placement_types.Shard = Shard
+    placement_types.Replicate = Replicate
+    placement_types.Partial = Partial
+    tensor.placement_types = placement_types
+
+    utils = types.ModuleType("torch.distributed.tensor._utils")
+    utils.compute_local_shape_and_global_offset = compute_local_shape_and_global_offset
+    tensor._utils = utils
+
+    device_mesh = types.ModuleType("torch.distributed.device_mesh")
+    device_mesh.DeviceMesh = DeviceMesh
+    device_mesh.init_device_mesh = init_device_mesh
+
+    return {
+        "torch.distributed.tensor": tensor,
+        "torch.distributed.tensor.placement_types": placement_types,
+        "torch.distributed.tensor._utils": utils,
+        "torch.distributed.device_mesh": device_mesh,
+    }
+
+
+def _build_fsdp_modules() -> dict[str, types.ModuleType]:
+    """``torch.distributed.fsdp`` and ``._composable.fsdp`` -- sharded training.
+
+    Inference never shards, but transformers imports the policy types at module
+    scope behind a torch-version check rather than an availability check.
+    """
+
+    class _Policy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class FSDPModule:
+        """dynamo's guard pickler issubclass()-tests against this; nothing
+        here ever subclasses it."""
+
+    def fully_shard(*args, **kwargs):
+        _no_peer("fully_shard")
+
+    fully_shard_mod = types.ModuleType("torch.distributed.fsdp._fully_shard")
+    fully_shard_mod.FSDPModule = FSDPModule
+    fully_shard_mod.fully_shard = fully_shard
+
+    def _fully_shard_getattr(name: str):
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        # dynamo probes for _fsdp_param_group behind
+        # `except ModuleNotFoundError`, and treats None as "no FSDP", which is
+        # exactly right here. Reporting anything else makes it trace into a
+        # subsystem that cannot work without real collectives.
+        raise ModuleNotFoundError(
+            f"torch.distributed.fsdp._fully_shard.{name} is not provided by "
+            "vLLM's single-rank stand-in.",
+            name="torch.distributed.fsdp._fully_shard",
+        )
+
+    fully_shard_mod.__getattr__ = _fully_shard_getattr
+
+    fsdp = types.ModuleType("torch.distributed.fsdp")
+    fsdp.__path__ = []  # marks it a package so submodule imports resolve
+    fsdp.OffloadPolicy = _Policy
+    fsdp.CPUOffloadPolicy = _Policy
+    fsdp.MixedPrecisionPolicy = _Policy
+    fsdp.FullyShardedDataParallel = _Policy
+    fsdp.ShardingStrategy = _Policy
+    fsdp.StateDictType = _Policy
+    fsdp.FSDPModule = FSDPModule
+    fsdp.fully_shard = fully_shard
+    fsdp._fully_shard = fully_shard_mod
+
+    composable = types.ModuleType("torch.distributed._composable")
+    composable.__path__ = []
+    composable_fsdp = types.ModuleType("torch.distributed._composable.fsdp")
+    composable_fsdp.__path__ = []
+    composable_fsdp.fully_shard = fully_shard
+    composable_fsdp.FSDPModule = FSDPModule
+    composable_fsdp.CPUOffloadPolicy = _Policy
+    composable_fsdp.MixedPrecisionPolicy = _Policy
+    composable_fsdp.OffloadPolicy = _Policy
+    composable_fsdp._fully_shard = fully_shard_mod
+    composable.fsdp = composable_fsdp
+
+    return {
+        "torch.distributed.fsdp": fsdp,
+        "torch.distributed.fsdp._fully_shard": fully_shard_mod,
+        "torch.distributed._composable": composable,
+        "torch.distributed._composable.fsdp": composable_fsdp,
+    }
+
+
+def _build_c_extension() -> types.ModuleType:
+    """``torch._C._distributed_c10d`` -- the pybind layer, in pure Python.
+
+    Type annotations across vLLM reference it by that path, so it has to be
+    both an attribute of ``torch._C`` and importable.
+    """
+    mod = types.ModuleType("torch._C._distributed_c10d")
+    mod.ProcessGroup = ProcessGroup
+    mod.ProcessGroupGloo = ProcessGroupGloo
+    mod.Work = Work
+    mod.ReduceOp = ReduceOp
+    mod.Store = Store
+    mod.PrefixStore = PrefixStore
+    mod.TCPStore = TCPStore
+    mod.FileStore = FileStore
+    mod.HashStore = Store
+    mod.BackendType = ProcessGroup.BackendType
+    mod._DEFAULT_PG_TIMEOUT = _get_default_timeout()
+    mod._register_process_group = _register_process_group
+    mod._unregister_process_group = _unregister_process_group
+    mod._resolve_process_group = _resolve_process_group
+
+    def __getattr__(name: str):
+        if name.startswith("__") and name.endswith("__"):
+            # Introspection (inspect.getmodule probing __file__, pickling
+            # probing __reduce__) must see a plain missing attribute.
+            raise AttributeError(name)
+        # Torch's own optional-import sites (dynamo's FSDP hooks, for one) are
+        # written as `try: from torch.distributed... except ModuleNotFoundError`.
+        # Anything we have not implemented genuinely is not there, so report it
+        # the way an absent extension module would and let those guards fire.
+        raise ModuleNotFoundError(
+            f"torch._C._distributed_c10d.{name} is not provided by vLLM's "
+            "single-rank stand-in; this PyTorch build has no c10d extension.",
+            name="torch._C._distributed_c10d",
+        )
+
+    mod.__getattr__ = __getattr__
+    return mod
+
+
+def _build_rendezvous() -> types.ModuleType:
+    """``torch.distributed.rendezvous`` -- how ranks find each other."""
+    mod = types.ModuleType("torch.distributed.rendezvous")
+    mod.rendezvous = rendezvous
+    mod.register_rendezvous_handler = lambda scheme, handler: None
+    return mod
+
+
+_EXPORTS = (
+    "ReduceOp Backend Work ProcessGroup ProcessGroupGloo "
+    "Store PrefixStore TCPStore FileStore "
+    "_world _get_default_timeout _get_default_group _register_process_group "
+    "_unregister_process_group _resolve_process_group "
+    "DistError DistBackendError DistNetworkError DistStoreError "
+    "is_initialized init_process_group destroy_process_group "
+    "new_group split_group new_subgroups_by_enumeration rendezvous "
+    "get_rank get_world_size get_backend get_process_group_ranks "
+    "get_group_rank get_global_rank is_backend_available is_gloo_available "
+    "is_nccl_available is_mpi_available is_ucc_available is_xccl_available "
+    "is_torchelastic_launched supports_complex "
+    "barrier monitored_barrier all_reduce reduce broadcast all_gather "
+    "all_gather_into_tensor gather scatter reduce_scatter "
+    "reduce_scatter_tensor all_to_all_single all_to_all all_gather_object "
+    "gather_object scatter_object_list broadcast_object_list "
+    "send recv isend irecv batch_isend_irecv P2POp"
+).split()
+
+# Aliases for store types vLLM names but never needs a real implementation of.
+TCPStore = Store
+FileStore = Store
+
+
+def install() -> bool:
+    """Graft the stand-in onto ``torch.distributed``. Returns True if applied."""
+    global _installed
+    if _installed or not is_needed():
+        return _installed
+    _installed = True
+
+    c_ext = _build_c_extension()
+    sys.modules["torch._C._distributed_c10d"] = c_ext
+    torch._C._distributed_c10d = c_ext
+
+    dist = torch.distributed
+    this = sys.modules[__name__]
+    for name in _EXPORTS:
+        setattr(dist, name, getattr(this, name))
+    dist.GroupMember = _GroupMember
+    dist.group = _GroupMember
+
+    c10d = _build_distributed_c10d(dist)
+    sys.modules["torch.distributed.distributed_c10d"] = c10d
+    dist.distributed_c10d = c10d
+
+    funcol = _build_functional_collectives()
+    sys.modules["torch.distributed._functional_collectives"] = funcol
+    dist._functional_collectives = funcol
+
+    symm = _build_symmetric_memory()
+    sys.modules["torch.distributed._symmetric_memory"] = symm
+    dist._symmetric_memory = symm
+
+    rdzv = _build_rendezvous()
+    sys.modules["torch.distributed.rendezvous"] = rdzv
+    dist.rendezvous = rdzv.rendezvous
+
+    for name, mod in (_build_dtensor_modules() | _build_fsdp_modules()).items():
+        sys.modules[name] = mod
+        parent, _, leaf = name.rpartition(".")
+        # Only bind direct children onto the package, or torch.distributed.fsdp
+        # would be clobbered by torch.distributed._composable.fsdp.
+        if parent == "torch.distributed":
+            setattr(dist, leaf, mod)
+    dist.DeviceMesh = sys.modules["torch.distributed.device_mesh"].DeviceMesh
+    dist.init_device_mesh = sys.modules[
+        "torch.distributed.device_mesh"
+    ].init_device_mesh
+
+    return True

--- a/vllm/v1/attention/ops/triton_merge_attn_states.py
+++ b/vllm/v1/attention/ops/triton_merge_attn_states.py
@@ -9,6 +9,118 @@ from vllm.triton_utils import tl, triton
 float8_info = torch.finfo(current_platform.fp8_dtype())
 
 
+def mask_empty_context(
+    lse: torch.Tensor,
+    output: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    context_start_loc: torch.Tensor,
+) -> None:
+    """Neutralize context chunks that cover no keys before merging.
+
+    A prefill query whose context chunk is empty attended to no keys, so its
+    partial attention is undefined: the backend leaves the output rows as
+    uninitialized scratch (which may hold NaN/Inf) even when it reports an LSE
+    of -inf. Sanitize both here so ``merge_attn_states`` can stay generic:
+    force the LSE to -inf (zero softmax weight) and zero the undefined output
+    rows (so a zero weight cannot combine with NaN/Inf). Emptiness is derived
+    from the context offsets, not from the -inf LSE, so no merge kernel has to
+    reason about undefined partials.
+
+    Args:
+        lse: Chunk log-sum-exp, shape [num_heads, num_tokens].
+        output: Chunk attention output, shape [num_tokens, num_heads, ...].
+        query_start_loc: Prefill query cumulative offsets, shape [num_reqs + 1].
+        context_start_loc: Chunk context cumulative offsets,
+            shape [num_reqs + 1]; an empty chunk has a zero-length span.
+    """
+    num_heads, num_tokens = lse.shape
+    num_reqs = query_start_loc.shape[0] - 1
+    block_size = 128
+    # Reserve the worst-case number of request-local blocks.
+    num_query_blocks = num_tokens // block_size + num_reqs
+    is_empty = torch.zeros(num_tokens, dtype=torch.bool, device=lse.device)
+    mask_empty_context_kernel[(num_query_blocks,)](
+        lse,
+        is_empty,
+        query_start_loc,
+        context_start_loc,
+        lse.stride(0),
+        lse.stride(1),
+        num_reqs,
+        NUM_HEADS=num_heads,
+        BLOCK_SIZE=block_size,
+        BLOCK_HEADS=8,
+        num_warps=8,
+    )
+    output.masked_fill_(is_empty[:, None, None], 0.0)
+
+
+@triton.jit
+def mask_empty_context_kernel(
+    lse,
+    is_empty,
+    query_start_loc,
+    context_start_loc,
+    lse_head_stride,
+    lse_token_stride,
+    num_reqs,
+    NUM_HEADS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    BLOCK_HEADS: tl.constexpr,
+):
+    query_block_idx = tl.program_id(0)
+
+    lanes = tl.arange(0, 32)
+    chunk_start = 0
+    req_idx = 0
+    req_idx_found = False
+    while (chunk_start < num_reqs) & (not req_idx_found):
+        req_offsets = chunk_start + lanes
+        req_mask = req_offsets < num_reqs
+        query_starts = tl.load(query_start_loc + req_offsets, mask=req_mask)
+        # Assume the worst-case number of blocks for each request.
+        req_block_starts = query_starts // BLOCK_SIZE + req_offsets
+        matched_idx = tl.sum(
+            (req_mask & (req_block_starts <= query_block_idx)).to(tl.int32)
+        )
+        # matched_idx == 32 means the match is past this warp chunk.
+        req_idx = chunk_start + matched_idx - 1
+        req_idx_found = matched_idx < 32
+        chunk_start += 32
+
+    query_start = tl.load(query_start_loc + req_idx)
+    query_end = tl.load(query_start_loc + req_idx + 1)
+    query_len = query_end - query_start
+    req_first_block = query_start // BLOCK_SIZE + req_idx
+    block_in_req = query_block_idx - req_first_block
+    token_offset = block_in_req * BLOCK_SIZE
+    if token_offset >= query_len:
+        return
+
+    context_start = tl.load(context_start_loc + req_idx)
+    context_end = tl.load(context_start_loc + req_idx + 1)
+    if context_start != context_end:
+        return
+
+    token_offsets = token_offset + tl.arange(0, BLOCK_SIZE)
+    token_indices = query_start + token_offsets
+    token_lse_offsets = token_indices * lse_token_stride
+    valid_tokens = token_offsets < query_len
+    tl.store(is_empty + token_indices, True, mask=valid_tokens)
+    head_offsets = tl.arange(0, BLOCK_HEADS)
+    for head_start in range(0, NUM_HEADS, BLOCK_HEADS):
+        head_indices = head_start + head_offsets
+        lse_ptrs = (
+            lse + head_indices[:, None] * lse_head_stride + token_lse_offsets[None, :]
+        )
+        valid_heads = head_indices < NUM_HEADS
+        tl.store(
+            lse_ptrs,
+            float("-inf"),
+            mask=valid_heads[:, None] & valid_tokens[None, :],
+        )
+
+
 # Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
 # can be used to combine partial attention results (in the split-KV case)
 def merge_attn_states(
@@ -136,6 +248,9 @@ def merge_attn_states_kernel(
 
     if OUTPUT_LSE:
         out_lse = tl.log(out_se) + max_lse
+        # Both sides empty (max_lse == -inf) => undefined merge; keep -inf so
+        # downstream merges continue to treat the token as empty.
+        out_lse = tl.where(max_lse == float("-inf"), float("-inf"), out_lse)
         tl.store(output_lse + head_idx * num_tokens + token_idx, out_lse)
 
     p_out = tl.load(
@@ -159,6 +274,10 @@ def merge_attn_states_kernel(
     p_scale = p_se / out_se
     s_scale = s_se / out_se
     out = p_out * p_scale + s_out * s_scale
+    # If both sides are empty (max_lse == -inf) the scales are 0/0 = NaN; emit
+    # zeros rather than NaN. Callers with empty chunks (see mask_empty_context)
+    # zero those inputs, so this only guards the fully-undefined corner.
+    out = tl.where(max_lse == float("-inf"), 0.0, out)
 
     if USE_FP8:
         out = out * (1.0 / tl.load(output_scale))

--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -145,7 +145,7 @@ class SchedulerInterface(ABC):
         self,
         request_ids: str | Iterable[str] | None,
         finished_status: "RequestStatus",
-    ) -> list[tuple[str, int]]:
+    ) -> "list[Request]":
         """Finish the requests in the scheduler's internal queue. If the request
         is not in the queue, this method will do nothing for that request.
 
@@ -159,8 +159,8 @@ class SchedulerInterface(ABC):
             finished_status: The finished status of the given requests.
 
         Returns:
-            Tuple of (req_id, client_index) for requests that were aborted. Will not
-            include any that were already finished.
+            List of requests that were aborted. Will not include any that were
+            already finished.
         """
         raise NotImplementedError
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -61,7 +61,7 @@ from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus, StreamingUpdate
 from vllm.v1.spec_decode.dynamic.utils import build_dynamic_sd_schedule_lookup
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
-from vllm.v1.structured_output import StructuredOutputManager
+from vllm.v1.structured_output import StructuredOutputGrammar, StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
 
 logger = init_logger(__name__)
@@ -201,6 +201,10 @@ class Scheduler(SchedulerInterface):
         # KV Connector: requests in process of async KV loading or recving
         self.finished_recving_kv_req_ids: set[str] = set()
         self.failed_recving_kv_req_ids: set[str] = set()
+
+        # Grammar compilation failures to finish as per-request errors in
+        # update_from_output.
+        self.grammar_compile_error_reqs: set[str] = set()
 
         # Encoder-related.
         # Calculate encoder cache size if applicable
@@ -1729,7 +1733,7 @@ class Scheduler(SchedulerInterface):
                 struct_output_request = request.structured_output_request
                 assert struct_output_request is not None
                 grammar = struct_output_request.grammar
-                assert grammar is not None
+                assert isinstance(grammar, StructuredOutputGrammar)
                 # new_token_ids can be a mixed block of reasoning content, then
                 # the reasoning end marker, then the start of the grammar content.
                 # Trim the reasoning content so the grammar only sees grammar content.
@@ -1859,10 +1863,16 @@ class Scheduler(SchedulerInterface):
             # This is a rare case and unlikely to impact performance.
             self.waiting.remove_requests(stopped_preempted_reqs)
 
+        error_req_ids = set(self.grammar_compile_error_reqs)
+        self.grammar_compile_error_reqs.clear()
         if failed_kv_load_req_ids and not self.recompute_kv_load_failures:
-            requests = [self.requests[req_id] for req_id in failed_kv_load_req_ids]
-            self.finish_requests(failed_kv_load_req_ids, RequestStatus.FINISHED_ERROR)
-            for request in requests:
+            error_req_ids.update(failed_kv_load_req_ids)
+
+        if error_req_ids:
+            error_reqs = self.finish_requests(
+                error_req_ids, RequestStatus.FINISHED_ERROR
+            )
+            for request in error_reqs:
                 outputs[request.client_index].append(
                     EngineCoreOutput(
                         request_id=request.request_id,
@@ -2092,8 +2102,7 @@ class Scheduler(SchedulerInterface):
             # Filter out spec tokens which do not adhere to the grammar.
             if self.structured_output_manager.should_advance(request):
                 metadata = request.structured_output_request
-                assert metadata is not None and metadata.grammar is not None
-                spec_token_ids = metadata.grammar.validate_tokens(spec_token_ids)
+                spec_token_ids = metadata.grammar.validate_tokens(spec_token_ids)  # type: ignore[union-attr]
             # Pad to original number of spec tokens.
             num_invalid_tokens = orig_num_spec_tokens - len(spec_token_ids)
             if num_invalid_tokens:
@@ -2134,7 +2143,7 @@ class Scheduler(SchedulerInterface):
 
     def finish_requests(
         self, request_ids: str | Iterable[str] | None, finished_status: RequestStatus
-    ) -> list[tuple[str, int]]:
+    ) -> list[Request]:
         """Handles the finish signal from outside the scheduler.
 
         For example, the API server can abort a request when the client
@@ -2143,8 +2152,8 @@ class Scheduler(SchedulerInterface):
         If request_ids is None, all requests will be finished.
 
         Returns:
-            Tuple of (req_id, client_index) for requests that were aborted. Will not
-            include any that were already finished.
+            List of requests that were aborted. Will not include any that were
+            already finished.
         """
         assert RequestStatus.is_finished(finished_status)
         if isinstance(request_ids, str):
@@ -2193,7 +2202,7 @@ class Scheduler(SchedulerInterface):
             request.status = finished_status
             self._free_request(request, delay_free_blocks=delay_free_blocks)
 
-        return [(r.request_id, r.client_index) for r in valid_requests]
+        return valid_requests
 
     def _free_request(
         self, request: Request, delay_free_blocks: bool = False
@@ -2593,7 +2602,10 @@ class Scheduler(SchedulerInterface):
 
         if request.status == RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR:
             structured_output_req = request.structured_output_request
-            if not (structured_output_req and structured_output_req.grammar):
+            if not structured_output_req or structured_output_req.grammar is None:
+                return False
+            if isinstance(structured_output_req.grammar, Exception):
+                self.grammar_compile_error_reqs.add(request.request_id)
                 return False
             request.status = RequestStatus.WAITING
             return True

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1830,13 +1830,13 @@ class EngineCoreProc(EngineCore):
     ) -> None:
         self._send_finish_outputs_to_client(req_ids, client_index, FinishReason.ERROR)
 
-    def _send_abort_outputs(self, aborted_reqs: list[tuple[str, int]]) -> None:
+    def _send_abort_outputs(self, aborted_reqs: list[Request]) -> None:
         # TODO(nick) this will be moved inside the scheduler
         if aborted_reqs:
             # Map client_index to list of request_ids that belong to that client.
             by_client = defaultdict[int, set[str]](set)
-            for req_id, client_index in aborted_reqs:
-                by_client[client_index].add(req_id)
+            for request in aborted_reqs:
+                by_client[request.client_index].add(request.request_id)
             for client_index, req_ids in by_client.items():
                 self._send_abort_outputs_to_client(list(req_ids), client_index)
 

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -3,6 +3,7 @@
 
 import contextlib
 import os
+import sys
 import threading
 import weakref
 from collections.abc import Callable, Iterator
@@ -1245,14 +1246,33 @@ def wait_for_engine_startup(
         and not parallel_config.data_parallel_external_lb
     )
 
-    if proc_manager is not None:
-        for sentinel in proc_manager.sentinels():
-            poller.register(sentinel, zmq.POLLIN)
-    if coord_process is not None:
-        poller.register(coord_process.sentinel, zmq.POLLIN)
+    # A multiprocessing sentinel is a pipe fd on POSIX, which zmq_poll accepts
+    # alongside sockets. On Windows it is a Win32 event HANDLE, which zmq_poll
+    # rejects outright ("not a socket"), so there we poll the handshake socket
+    # alone and check for dead children between polls instead.
+    poll_sentinels = sys.platform != "win32"
+    if poll_sentinels:
+        if proc_manager is not None:
+            for sentinel in proc_manager.sentinels():
+                poller.register(sentinel, zmq.POLLIN)
+        if coord_process is not None:
+            poller.register(coord_process.sentinel, zmq.POLLIN)
+
+    def finished_procs() -> dict[str, int]:
+        finished = proc_manager.finished_procs() if proc_manager else {}
+        if coord_process is not None and coord_process.exitcode is not None:
+            finished[coord_process.name] = coord_process.exitcode
+        return finished
+
     while any(conn_pending) or any(start_pending):
         events = poller.poll(STARTUP_POLL_PERIOD_MS)
         if not events:
+            if not poll_sentinels and (finished := finished_procs()):
+                raise RuntimeError(
+                    "Engine core initialization failed. "
+                    "See root cause above. "
+                    f"Failed core proc(s): {finished}"
+                )
             if any(conn_pending):
                 logger.debug(
                     "Waiting for %d local, %d remote core engine proc(s) to connect.",
@@ -1266,13 +1286,10 @@ def wait_for_engine_startup(
             continue
         if len(events) > 1 or events[0][0] != handshake_socket:
             # One of the local core processes exited.
-            finished = proc_manager.finished_procs() if proc_manager else {}
-            if coord_process is not None and coord_process.exitcode is not None:
-                finished[coord_process.name] = coord_process.exitcode
             raise RuntimeError(
                 "Engine core initialization failed. "
                 "See root cause above. "
-                f"Failed core proc(s): {finished}"
+                f"Failed core proc(s): {finished_procs()}"
             )
 
         # Receive HELLO and READY messages from the input socket.

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -164,24 +164,33 @@ class StructuredOutputManager:
             else:
                 raise ValueError(f"Unsupported structured output backend: {backend}")
 
+        grammar: Future[StructuredOutputGrammar] | StructuredOutputGrammar
         if self._use_async_grammar_compilation:
             grammar = self.executor.submit(self._create_grammar, request)
         else:
-            grammar = self._create_grammar(request)  # type: ignore[assignment]
-        request.structured_output_request.grammar = grammar  # type: ignore[assignment]
+            try:
+                grammar = self._create_grammar(request)
+            except Exception as e:
+                grammar = Future()
+                grammar.set_exception(e)
+        request.structured_output_request.grammar = grammar
 
     def _create_grammar(self, request: "Request") -> StructuredOutputGrammar:
-        key = request.structured_output_request.structured_output_key  # type: ignore[union-attr]
-
+        struct_request = request.structured_output_request
+        assert struct_request is not None
         # Note that the request was validated in the engine core client,
-        # so at this point we know it is a supported type of request.
-        #
-        # TODO: we still need to handle xgrammar compilation failures,
-        # though it should be unlikely as we test that up front as well.
-        request_type, grammar_spec = key
-
-        assert self.backend is not None
-        return self.backend.compile_grammar(request_type, grammar_spec)
+        # so at this point we know it is a supported type of request. Grammar
+        # compilation may still fail; the Future carries that error to the
+        # scheduler so it can fail only this request.
+        try:
+            request_type, grammar_spec = struct_request.structured_output_key
+            assert self.backend is not None
+            return self.backend.compile_grammar(request_type, grammar_spec)
+        except Exception:
+            logger.exception(
+                "Failed to compile grammar for request %s", request.request_id
+            )
+            raise
 
     def _fill_bitmasks(
         self, batch: Iterable[tuple[StructuredOutputGrammar, int, bool]]
@@ -244,8 +253,9 @@ class StructuredOutputManager:
                 structured_output_request = request.structured_output_request
                 if TYPE_CHECKING:
                     assert structured_output_request is not None
-                    assert structured_output_request.grammar is not None
                 grammar = structured_output_request.grammar
+                if TYPE_CHECKING:
+                    assert isinstance(grammar, StructuredOutputGrammar)
 
                 apply_bitmask = self.should_fill_bitmask(request)
                 batch.append((grammar, cumulative_index, apply_bitmask))
@@ -268,8 +278,9 @@ class StructuredOutputManager:
 
                 if TYPE_CHECKING:
                     assert structured_output_request is not None
-                    assert structured_output_request.grammar is not None
                 grammar = structured_output_request.grammar
+                if TYPE_CHECKING:
+                    assert isinstance(grammar, StructuredOutputGrammar)
                 apply_bitmask = self.should_fill_bitmask(request)
 
                 reasoner = self._get_reasoner(request)

--- a/vllm/v1/structured_output/request.py
+++ b/vllm/v1/structured_output/request.py
@@ -21,7 +21,9 @@ if TYPE_CHECKING:
 @dataclasses.dataclass
 class StructuredOutputRequest:
     params: StructuredOutputsParams
-    _grammar: Future[StructuredOutputGrammar] | StructuredOutputGrammar | None = None
+    _grammar: (
+        Future[StructuredOutputGrammar] | StructuredOutputGrammar | Exception | None
+    ) = None
     reasoning_ended: bool | None = None
     # Absolute index into the request's all_token_ids of the last reasoning
     # token (the reasoning-end marker). Tokens at or before this index are
@@ -56,6 +58,8 @@ class StructuredOutputRequest:
                 self.status = RequestStatus.WAITING
             except TimeoutError:
                 return False
+            except Exception as e:
+                self._grammar = e
         return True
 
     @property
@@ -63,11 +67,10 @@ class StructuredOutputRequest:
         return self._check_grammar_completion()
 
     @property
-    def grammar(self) -> StructuredOutputGrammar | None:
-        completed = self._check_grammar_completion()
-        return (
-            cast(StructuredOutputGrammar | None, self._grammar) if completed else None
-        )
+    def grammar(self) -> StructuredOutputGrammar | Exception | None:
+        if not self._check_grammar_completion():
+            return None
+        return cast(StructuredOutputGrammar | Exception | None, self._grammar)
 
     @grammar.setter
     def grammar(

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -23,7 +23,7 @@ from typing import (
 )
 
 import torch
-import uvloop
+from vllm.utils.async_utils import run_async
 from torch.autograd.profiler import record_function
 
 import vllm.envs as envs
@@ -509,7 +509,7 @@ def run_api_server_worker_proc(
     set_process_title("APIServer", str(server_index))
     decorate_logs()
 
-    uvloop.run(
+    run_async(
         run_server_worker(listen_address, sock, args, client_config, **uvicorn_kwargs)
     )
 

--- a/vllm/v1/worker/gpu/sample/states.py
+++ b/vllm/v1/worker/gpu/sample/states.py
@@ -50,7 +50,9 @@ class SamplingStates:
         seed = sampling_params.seed
         self.seeds_set[req_idx] = seed is not None
         if seed is None:
-            seed = np.random.randint(_NP_INT64_MIN, _NP_INT64_MAX)
+            # dtype is required: randint defaults to C long, which is 32-bit
+            # on Windows and rejects these bounds.
+            seed = np.random.randint(_NP_INT64_MIN, _NP_INT64_MAX, dtype=np.int64)
         self.seeds.np[req_idx] = seed
 
         num_logprobs = sampling_params.logprobs

--- a/vram_guard.ps1
+++ b/vram_guard.ps1
@@ -49,6 +49,8 @@ param(
     [double]$WarnGiB = 23.0,
     [int]$IntervalSec = 3,
     [int]$Consecutive = 3,
+    [int]$CounterTimeoutSec = 5,
+    [int]$CounterFailureLimit = 3,
     [string]$StallLogPath = '',
     [int]$StallSec = 300,
     [string]$LogPath = 'C:\AI\vllm\vram_guard.log'
@@ -63,13 +65,49 @@ function Write-Guard([string]$Message) {
 }
 
 function Get-VramGiB {
-    # Total dedicated VRAM on the adapter -- the desktop's share counts too.
+    # Query in a disposable helper process. A GPU reset can wedge Get-Counter
+    # itself; keeping it in the watchdog process would prevent stall cleanup.
+    $counterScript = @'
+$samples = (Get-Counter '\GPU Adapter Memory(*)\Dedicated Usage' -ErrorAction Stop).CounterSamples
+if (-not $samples) { exit 2 }
+$bytes = ($samples | Measure-Object -Property CookedValue -Maximum).Maximum
+[Console]::Out.Write([string]::Format(
+    [Globalization.CultureInfo]::InvariantCulture, '{0:R}', [double]$bytes))
+'@
+    $encoded = [Convert]::ToBase64String(
+        [Text.Encoding]::Unicode.GetBytes($counterScript)
+    )
+    $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+    $startInfo.FileName = 'powershell.exe'
+    $startInfo.Arguments = "-NoProfile -EncodedCommand $encoded"
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $helper = New-Object System.Diagnostics.Process
+    $helper.StartInfo = $startInfo
+
     try {
-        $s = (Get-Counter '\GPU Adapter Memory(*)\Dedicated Usage' -ErrorAction Stop).CounterSamples
-        if (-not $s) { return $null }
-        return (($s | Measure-Object -Property CookedValue -Maximum).Maximum / 1GB)
+        if (-not $helper.Start()) { return $null }
+        if (-not $helper.WaitForExit($CounterTimeoutSec * 1000)) {
+            try { $helper.Kill() } catch { }
+            return $null
+        }
+        $raw = $helper.StandardOutput.ReadToEnd().Trim()
+        if ($helper.ExitCode -ne 0 -or -not $raw) { return $null }
+
+        $bytes = 0.0
+        $parsed = [double]::TryParse(
+            $raw,
+            [Globalization.NumberStyles]::Float,
+            [Globalization.CultureInfo]::InvariantCulture,
+            [ref]$bytes
+        )
+        if (-not $parsed) { return $null }
+        return $bytes / 1GB
     }
     catch { return $null }
+    finally { $helper.Dispose() }
 }
 
 function Update-TrackedProcessTree(
@@ -125,7 +163,12 @@ function Stop-Tree(
 }
 
 Write-Guard "=== vram_guard start ==="
-$baseline = Get-VramGiB
+$baseline = $null
+foreach ($attempt in 1..$CounterFailureLimit) {
+    $baseline = Get-VramGiB
+    if ($null -ne $baseline) { break }
+    Write-Guard "WARNING: VRAM counter attempt ${attempt}/${CounterFailureLimit} failed."
+}
 if ($null -eq $baseline) {
     Write-Guard 'ERROR: GPU memory counters unavailable; refusing to launch unguarded.'
     exit 98
@@ -142,6 +185,7 @@ $trackedPids = [System.Collections.Generic.HashSet[int]]::new()
 [void]$trackedPids.Add($proc.Id)
 
 $breaches = 0
+$counterFailures = 0
 $peak = 0.0
 $killed = ''
 $startedAt = Get-Date
@@ -151,7 +195,17 @@ while (-not $proc.HasExited) {
     Update-TrackedProcessTree -TrackedPids $trackedPids
 
     $used = Get-VramGiB
-    if ($null -ne $used) {
+    if ($null -eq $used) {
+        $counterFailures++
+        Write-Guard "VRAM counter unavailable (${counterFailures}/${CounterFailureLimit})"
+        if ($counterFailures -ge $CounterFailureLimit) {
+            $killed = "VRAM counter unavailable for $counterFailures consecutive samples"
+            Stop-Tree -TreePid $proc.Id -Why $killed -TrackedPids $trackedPids
+            break
+        }
+    }
+    else {
+        $counterFailures = 0
         if ($used -gt $peak) { $peak = $used }
         if ($used -ge $LimitGiB) {
             $breaches++

--- a/vram_guard.ps1
+++ b/vram_guard.ps1
@@ -1,0 +1,153 @@
+<#
+.SYNOPSIS
+    Run a vLLM command under a watchdog: kills it on VRAM exhaustion or a stall.
+
+.DESCRIPTION
+    Two failure modes on this box take the whole machine down, and this guards
+    against both.
+
+    1. VRAM exhaustion. vLLM claims `gpu-memory-utilization` of the card and
+       sizes its KV cache to fill whatever the weights leave over, so even a
+       small model will allocate ~27 GiB on a 32 GiB card. This GPU also drives
+       the desktop, and RDNA4 falls off a large-GEMM cliff under ~3 GiB free.
+
+    2. Stalls. HIP graph replay can wedge (observed with FP8 Qwen3-8B on
+       gfx1201): the process pins a core, holds all its VRAM, and never
+       returns. Nothing times this out on its own.
+
+    The watchdog samples the adapter's dedicated VRAM and, if given
+    -StallLogPath, the mtime of the run's own log. Either breach kills the
+    whole process tree.
+
+.PARAMETER Command
+    Command line to run, executed via cmd.exe /c. Redirect the command's own
+    output inside this string; the watchdog does not capture it.
+
+.PARAMETER LimitGiB
+    Kill threshold for total dedicated VRAM on the adapter.
+
+.PARAMETER WarnGiB
+    Log a warning at this level without killing.
+
+.PARAMETER StallLogPath
+    If set, kill the run when this file has not been written for -StallSec.
+    Point it at the log your -Command redirects into.
+
+.PARAMETER StallSec
+    Seconds of no log growth before declaring a stall. Must comfortably exceed
+    the longest legitimately quiet phase; torch.compile plus graph capture can
+    run ~120 s silently on an 8B.
+
+.EXAMPLE
+    $log = "C:\AI\vllm\run.log"
+    .\vram_guard.ps1 -StallLogPath $log -Command "C:\AI\vllm\bench_windows_rocm.cmd throughput --model C:\AI\models\Qwen3-8B-FP8-Dynamic > `"$log`" 2>&1"
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$Command,
+    [double]$LimitGiB = 26.0,
+    [double]$WarnGiB = 23.0,
+    [int]$IntervalSec = 3,
+    [int]$Consecutive = 3,
+    [string]$StallLogPath = '',
+    [int]$StallSec = 300,
+    [string]$LogPath = 'C:\AI\vllm\vram_guard.log'
+)
+
+$ErrorActionPreference = 'Continue'
+
+function Write-Guard([string]$Message) {
+    $line = "[{0}] {1}" -f (Get-Date -Format 'HH:mm:ss'), $Message
+    Write-Host $line
+    try { Add-Content -Path $LogPath -Value $line } catch { }
+}
+
+function Get-VramGiB {
+    # Total dedicated VRAM on the adapter -- the desktop's share counts too.
+    try {
+        $s = (Get-Counter '\GPU Adapter Memory(*)\Dedicated Usage' -ErrorAction Stop).CounterSamples
+        if (-not $s) { return $null }
+        return (($s | Measure-Object -Property CookedValue -Maximum).Maximum / 1GB)
+    }
+    catch { return $null }
+}
+
+function Stop-Tree([int]$TreePid, [string]$Why) {
+    Write-Guard "KILLING pid ${TreePid}: $Why"
+    & taskkill.exe /PID $TreePid /T /F 2>&1 | Out-Null
+    Start-Sleep -Seconds 2
+    # The engine core is a spawned grandchild and outlives a tree kill once the
+    # intermediate shell is gone, so sweep any surviving interpreters.
+    foreach ($p in @(Get-Process python -ErrorAction SilentlyContinue)) {
+        & taskkill.exe /PID $p.Id /T /F 2>&1 | Out-Null
+    }
+}
+
+Write-Guard "=== vram_guard start ==="
+$baseline = Get-VramGiB
+if ($null -eq $baseline) {
+    Write-Guard 'WARNING: GPU memory counters unavailable - VRAM guard INACTIVE.'
+}
+else {
+    Write-Guard ('baseline {0:N2} GiB | limit {1:N2} | warn {2:N2}' -f $baseline, $LimitGiB, $WarnGiB)
+}
+if ($StallLogPath) { Write-Guard "stall guard: $StallLogPath idle > ${StallSec}s" }
+Write-Guard "command: $Command"
+
+$proc = Start-Process -FilePath 'cmd.exe' -ArgumentList '/c', $Command -PassThru -WindowStyle Hidden
+Write-Guard "child pid $($proc.Id)"
+
+$breaches = 0
+$peak = 0.0
+$killed = ''
+$startedAt = Get-Date
+
+while (-not $proc.HasExited) {
+    Start-Sleep -Seconds $IntervalSec
+
+    $used = Get-VramGiB
+    if ($null -ne $used) {
+        if ($used -gt $peak) { $peak = $used }
+        if ($used -ge $LimitGiB) {
+            $breaches++
+            Write-Guard ('VRAM {0:N2} GiB >= {1:N2} ({2}/{3})' -f $used, $LimitGiB, $breaches, $Consecutive)
+            if ($breaches -ge $Consecutive) {
+                $killed = 'VRAM {0:N2} GiB exceeded limit {1:N2} GiB' -f $used, $LimitGiB
+                Stop-Tree -TreePid $proc.Id -Why $killed
+                break
+            }
+        }
+        else {
+            if ($breaches -gt 0) { Write-Guard ('VRAM back to {0:N2} GiB' -f $used) }
+            $breaches = 0
+            if ($used -ge $WarnGiB) { Write-Guard ('warn: VRAM {0:N2} GiB' -f $used) }
+        }
+    }
+
+    if ($StallLogPath -and (Test-Path $StallLogPath)) {
+        $idle = ((Get-Date) - (Get-Item $StallLogPath).LastWriteTime).TotalSeconds
+        if ($idle -ge $StallSec) {
+            $killed = 'stalled: no log output for {0:N0}s' -f $idle
+            Stop-Tree -TreePid $proc.Id -Why $killed
+            break
+        }
+    }
+    elseif ($StallLogPath) {
+        # Log not created yet; treat time since launch as the idle period.
+        $idle = ((Get-Date) - $startedAt).TotalSeconds
+        if ($idle -ge $StallSec) {
+            $killed = 'stalled: log never created after {0:N0}s' -f $idle
+            Stop-Tree -TreePid $proc.Id -Why $killed
+            break
+        }
+    }
+}
+
+if ($killed) {
+    Write-Guard ('killed by watchdog ({0}); peak VRAM {1:N2} GiB' -f $killed, $peak)
+    exit 99
+}
+
+$proc.WaitForExit()
+Write-Guard ('exited {0}; peak VRAM {1:N2} GiB' -f $proc.ExitCode, $peak)
+exit $proc.ExitCode

--- a/vram_guard.ps1
+++ b/vram_guard.ps1
@@ -179,7 +179,11 @@ else {
 if ($StallLogPath) { Write-Guard "stall guard: $StallLogPath idle > ${StallSec}s" }
 Write-Guard "command: $Command"
 
-$proc = Start-Process -FilePath 'cmd.exe' -ArgumentList '/c', $Command -PassThru -WindowStyle Hidden
+# cmd.exe requires an additional outer quote pair when the command itself
+# starts with a quoted executable path. Without it, Start-Process argument
+# serialization can strip the executable quotes and lose redirections.
+$cmdCommand = '"' + $Command + '"'
+$proc = Start-Process -FilePath 'cmd.exe' -ArgumentList '/d', '/s', '/c', $cmdCommand -PassThru -WindowStyle Hidden
 Write-Guard "child pid $($proc.Id)"
 $trackedPids = [System.Collections.Generic.HashSet[int]]::new()
 [void]$trackedPids.Add($proc.Id)

--- a/vram_guard.ps1
+++ b/vram_guard.ps1
@@ -72,21 +72,63 @@ function Get-VramGiB {
     catch { return $null }
 }
 
-function Stop-Tree([int]$TreePid, [string]$Why) {
+function Update-TrackedProcessTree(
+    [System.Collections.Generic.HashSet[int]]$TrackedPids
+) {
+    try {
+        $processes = @(Get-CimInstance Win32_Process -ErrorAction Stop |
+            Select-Object ProcessId, ParentProcessId)
+        do {
+            $added = $false
+            foreach ($candidate in $processes) {
+                $candidatePid = [int]$candidate.ProcessId
+                $parentPid = [int]$candidate.ParentProcessId
+                if (
+                    $TrackedPids.Contains($parentPid) -and
+                    $TrackedPids.Add($candidatePid)
+                ) {
+                    $added = $true
+                }
+            }
+        } while ($added)
+    }
+    catch {
+        Write-Guard "WARNING: could not refresh child process list: $($_.Exception.Message)"
+    }
+}
+
+function Stop-Tree(
+    [int]$TreePid,
+    [string]$Why,
+    [System.Collections.Generic.HashSet[int]]$TrackedPids
+) {
     Write-Guard "KILLING pid ${TreePid}: $Why"
+
+    # Preserve every descendant PID before terminating the root. EngineCore is
+    # spawned through intermediate processes, and Windows keeps its original
+    # ParentProcessId even if an intermediate parent has already exited.
+    Update-TrackedProcessTree -TrackedPids $TrackedPids
     & taskkill.exe /PID $TreePid /T /F 2>&1 | Out-Null
-    Start-Sleep -Seconds 2
-    # The engine core is a spawned grandchild and outlives a tree kill once the
-    # intermediate shell is gone, so sweep any surviving interpreters.
-    foreach ($p in @(Get-Process python -ErrorAction SilentlyContinue)) {
-        & taskkill.exe /PID $p.Id /T /F 2>&1 | Out-Null
+
+    # A spawned grandchild can outlive taskkill /T after its intermediate
+    # parent exits. Kill only PIDs observed in this run, never unrelated Python
+    # processes on the machine. A second pass catches children racing shutdown.
+    foreach ($pass in 1..2) {
+        Start-Sleep -Seconds 1
+        Update-TrackedProcessTree -TrackedPids $TrackedPids
+        foreach ($trackedPid in (@($TrackedPids) | Sort-Object -Descending)) {
+            if (Get-Process -Id $trackedPid -ErrorAction SilentlyContinue) {
+                & taskkill.exe /PID $trackedPid /T /F 2>&1 | Out-Null
+            }
+        }
     }
 }
 
 Write-Guard "=== vram_guard start ==="
 $baseline = Get-VramGiB
 if ($null -eq $baseline) {
-    Write-Guard 'WARNING: GPU memory counters unavailable - VRAM guard INACTIVE.'
+    Write-Guard 'ERROR: GPU memory counters unavailable; refusing to launch unguarded.'
+    exit 98
 }
 else {
     Write-Guard ('baseline {0:N2} GiB | limit {1:N2} | warn {2:N2}' -f $baseline, $LimitGiB, $WarnGiB)
@@ -96,6 +138,8 @@ Write-Guard "command: $Command"
 
 $proc = Start-Process -FilePath 'cmd.exe' -ArgumentList '/c', $Command -PassThru -WindowStyle Hidden
 Write-Guard "child pid $($proc.Id)"
+$trackedPids = [System.Collections.Generic.HashSet[int]]::new()
+[void]$trackedPids.Add($proc.Id)
 
 $breaches = 0
 $peak = 0.0
@@ -104,6 +148,7 @@ $startedAt = Get-Date
 
 while (-not $proc.HasExited) {
     Start-Sleep -Seconds $IntervalSec
+    Update-TrackedProcessTree -TrackedPids $trackedPids
 
     $used = Get-VramGiB
     if ($null -ne $used) {
@@ -113,7 +158,7 @@ while (-not $proc.HasExited) {
             Write-Guard ('VRAM {0:N2} GiB >= {1:N2} ({2}/{3})' -f $used, $LimitGiB, $breaches, $Consecutive)
             if ($breaches -ge $Consecutive) {
                 $killed = 'VRAM {0:N2} GiB exceeded limit {1:N2} GiB' -f $used, $LimitGiB
-                Stop-Tree -TreePid $proc.Id -Why $killed
+                Stop-Tree -TreePid $proc.Id -Why $killed -TrackedPids $trackedPids
                 break
             }
         }
@@ -128,7 +173,7 @@ while (-not $proc.HasExited) {
         $idle = ((Get-Date) - (Get-Item $StallLogPath).LastWriteTime).TotalSeconds
         if ($idle -ge $StallSec) {
             $killed = 'stalled: no log output for {0:N0}s' -f $idle
-            Stop-Tree -TreePid $proc.Id -Why $killed
+            Stop-Tree -TreePid $proc.Id -Why $killed -TrackedPids $trackedPids
             break
         }
     }
@@ -137,7 +182,7 @@ while (-not $proc.HasExited) {
         $idle = ((Get-Date) - $startedAt).TotalSeconds
         if ($idle -ge $StallSec) {
             $killed = 'stalled: log never created after {0:N0}s' -f $idle
-            Stop-Tree -TreePid $proc.Id -Why $killed
+            Stop-Tree -TreePid $proc.Id -Why $killed -TrackedPids $trackedPids
             break
         }
     }


### PR DESCRIPTION


## Purpose

Addconfigurable `gfx1200` support for native-Windows ROCm while preserving
`gfx1201` as the backward-compatible default.

This adds a `-GpuArch` parameter to `setup_windows_rocm.ps1` and passes the
selected architecture consistently to `PYTORCH_ROCM_ARCH` and
`CMAKE_HIP_ARCHITECTURES`.

The change also fixes two Windows PowerShell issues encountered during setup:

- Python version-check quoting when invoking `python -c`.
- Quoted executable and log-redirection handling in `vram_guard.ps1`.

Documentation for the Radeon RX 9060 XT configuration and current limitations
is included.

## Test Plan

Tested on:

- Windows 11
- AMD Radeon RX 9060 XT, 16 GiB
- GPU architecture: `gfx1200`
- PyTorch: `2.11.0+rocm7.13.0`
- HIP: `7.13.99004`
- Triton Windows: `3.6.0.post26`
- Model: `Qwen/Qwen3-0.6B`

Setup configuration:

```powershell
.\setup_windows_rocm.ps1 `
  -GpuArch gfx1200 `
  -MaxJobs 6 `
  -GuardWarnGiB 13 `
  -GuardLimitGiB 14.5