### PR TITLE
Fix stable base detection on Linux sync runner

### DIFF
--- a/update_windows_rocm.ps1
+++ b/update_windows_rocm.ps1
@@ -167,7 +167,10 @@ Write-Host "Fetching upstream $selectedTag..." -ForegroundColor Cyan
     "refs/tags/${selectedTag}:refs/tags/${selectedTag}"
 ))
 
-$mergedTags = @(Invoke-Git @('tag', '--merged', 'HEAD', '--list', 'v*'))
+$mergedTags = @(
+    Invoke-Git @('tag', '--merged', 'HEAD', '--list') |
+        Where-Object { $null -ne (ConvertTo-StableVersion $_) }
+)
 $currentBase = Get-NewestStableTag $mergedTags
 if (-not $currentBase) {
     throw 'Could not identify a stable upstream tag in the current history.'


### PR DESCRIPTION
Avoid passing the v* tag pattern to native Git under PowerShell on Linux. PowerShell expanded it against checkout paths, so the updater could not recognize that windows-rocm is based on v0.27.1. Stable tags are now listed without a native wildcard and filtered in PowerShell. Local check: CURRENT_BASE=v0.27.1, LATEST_STABLE=v0.28.0, UPDATE_AVAILABLE=true.