### PR TITLE
Make Windows multiprocessing and shutdown plugin-safe

### DIFF
--- a/tests/v1/engine/test_windows_process_compat.py
+++ b/tests/v1/engine/test_windows_process_compat.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import pytest
+
+import vllm.v1.engine.utils as engine_utils
+
+
+class _FakeProcess:
+    name = "EngineCore"
+
+    def __init__(self) -> None:
+        self.join_timeout: float | None = None
+
+    def is_alive(self) -> bool:
+        return True
+
+    def join(self, timeout: float | None = None) -> None:
+        self.join_timeout = timeout
+
+
+def test_cooperative_shutdown_waits_before_forced_shutdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event = Mock()
+    process = _FakeProcess()
+    forced_shutdown = Mock()
+    monkeypatch.setattr(engine_utils, "shutdown", forced_shutdown)
+    monkeypatch.setattr(
+        engine_utils.envs,
+        "VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS",
+        7,
+    )
+    monkeypatch.setattr(engine_utils.time, "monotonic", lambda: 100.0)
+
+    engine_utils._shutdown_core_processes(
+        [process],  # type: ignore[list-item]
+        shutdown_event=event,
+        timeout=3.0,
+    )
+
+    event.set.assert_called_once_with()
+    assert process.join_timeout == 17.0
+    forced_shutdown.assert_called_once_with([process], timeout=3.0)
+
+
+def test_posix_shutdown_path_remains_direct(monkeypatch: pytest.MonkeyPatch) -> None:
+    process = _FakeProcess()
+    forced_shutdown = Mock()
+    monkeypatch.setattr(engine_utils, "shutdown", forced_shutdown)
+
+    engine_utils._shutdown_core_processes([process], timeout=2.0)  # type: ignore[list-item]
+
+    assert process.join_timeout is None
+    forced_shutdown.assert_called_once_with([process], timeout=2.0)

--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -38,14 +38,17 @@ logger = init_logger(__name__)
 # We prefer to use os.sched_yield as it results in tighter polling loops,
 # measured to be around 3e-7 seconds. However on earlier versions of Python
 # os.sched_yield() does not release the GIL, so we fall back to time.sleep(0)
-USE_SCHED_YIELD = (sys.version_info[:3] >= (3, 11, 1)) or (
-    sys.version_info[:2] == (3, 10) and sys.version_info[2] >= 8
+_OS_SCHED_YIELD = getattr(os, "sched_yield", None)
+USE_SCHED_YIELD = _OS_SCHED_YIELD is not None and (
+    (sys.version_info[:3] >= (3, 11, 1))
+    or (sys.version_info[:2] == (3, 10) and sys.version_info[2] >= 8)
 )
 
 
 def sched_yield():
     if USE_SCHED_YIELD:
-        os.sched_yield()
+        assert _OS_SCHED_YIELD is not None
+        _OS_SCHED_YIELD()
     else:
         time.sleep(0)
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1274,6 +1274,11 @@ class EngineCoreProc(EngineCore):
         # Ensure we can serialize transformer config after spawning
         maybe_register_config_serialize_by_value()
 
+        # Process.terminate() bypasses Python signal handlers on Windows. The
+        # local process manager supplies this spawn-safe event so EngineCore
+        # can take its normal worker and HIP-resource shutdown path first.
+        shutdown_event = kwargs.pop("shutdown_event", None)
+
         engine_core: EngineCoreProc | None = None
         signal_callback: SignalCallback | None = None
         try:
@@ -1335,6 +1340,24 @@ class EngineCoreProc(EngineCore):
 
             signal.signal(signal.SIGTERM, signal_handler)
             signal.signal(signal.SIGINT, signal_handler)
+
+            if shutdown_event is not None:
+
+                def shutdown_event_monitor():
+                    shutdown_event.wait()
+                    if engine_core.shutdown_state == EngineShutdownState.RUNNING:
+                        logger.info(
+                            "[shutdown] EngineCore: cooperative Windows "
+                            "shutdown requested"
+                        )
+                        engine_core.shutdown_state = EngineShutdownState.REQUESTED
+                        signal_callback.trigger()
+
+                threading.Thread(
+                    target=shutdown_event_monitor,
+                    daemon=True,
+                    name="EngineCoreWindowsShutdown",
+                ).start()
 
             engine_core.run_busy_loop()
 

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -5,6 +5,7 @@ import contextlib
 import os
 import sys
 import threading
+import time
 import weakref
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
@@ -41,6 +42,42 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 STARTUP_POLL_PERIOD_MS = 10000
+
+
+def _shutdown_core_processes(
+    processes: list[BaseProcess],
+    shutdown_event=None,
+    timeout: float | None = None,
+) -> None:
+    """Cooperatively stop EngineCore children before forced termination.
+
+    ``multiprocessing.Process.terminate()`` calls ``TerminateProcess`` on
+    Windows. That bypasses Python signal handlers and the EngineCore worker
+    cleanup path, so give Windows children an explicit, spawn-safe event first.
+    POSIX callers keep the existing shutdown behavior because their event is
+    ``None``.
+    """
+    if shutdown_event is not None:
+        shutdown_event.set()
+        # EngineCore first gives its worker processes the configured shutdown
+        # timeout. The outer grace period must extend past that inner deadline
+        # so it does not terminate EngineCore just before worker cleanup ends.
+        grace_timeout = (
+            max(
+                float(timeout or 0),
+                float(envs.VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS),
+            )
+            + 10.0
+        )
+        deadline = time.monotonic() + grace_timeout
+        for proc in processes:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            if proc.is_alive():
+                proc.join(remaining)
+
+    shutdown(processes, timeout=timeout)
 
 
 class CoreEngineState(Enum):
@@ -138,6 +175,7 @@ class CoreEngineProcManager:
         tensor_queue: Queue | None = None,
     ):
         context = get_mp_context()
+        self.shutdown_event = context.Event() if sys.platform == "win32" else None
         common_kwargs = {
             "vllm_config": vllm_config,
             "local_client": local_client,
@@ -146,6 +184,8 @@ class CoreEngineProcManager:
             "log_stats": log_stats,
             "tensor_queue": tensor_queue,
         }
+        if self.shutdown_event is not None:
+            common_kwargs["shutdown_event"] = self.shutdown_event
 
         if client_handshake_address:
             common_kwargs["client_handshake_address"] = client_handshake_address
@@ -171,7 +211,12 @@ class CoreEngineProcManager:
                 )
             )
 
-        self._finalizer = weakref.finalize(self, shutdown, self.processes)
+        self._finalizer = weakref.finalize(
+            self,
+            _shutdown_core_processes,
+            self.processes,
+            self.shutdown_event,
+        )
         self.manager_stopped = threading.Event()
         self.failed_proc_name: str | None = None
 
@@ -218,7 +263,11 @@ class CoreEngineProcManager:
         """Shutdown engine core processes with configurable timeout."""
         self.manager_stopped.set()
         if self._finalizer.detach() is not None:
-            shutdown(self.processes, timeout=timeout)
+            _shutdown_core_processes(
+                self.processes,
+                self.shutdown_event,
+                timeout=timeout,
+            )
 
     def monitor_engine_liveness(self) -> None:
         """Monitor engine core process liveness."""

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -787,8 +787,12 @@ class WorkerProc:
         )
         while pipes:
             ready = multiprocessing.connection.wait(pipes.keys())
-            for pipe in ready:
-                assert isinstance(pipe, Connection)
+            for ready_pipe in ready:
+                # ``multiprocessing.Pipe`` returns ``PipeConnection`` on
+                # Windows rather than the POSIX ``Connection`` class. Both
+                # implement recv(), and connection.wait() deliberately
+                # accepts either implementation.
+                pipe = cast(Connection, ready_pipe)
                 try:
                     # Wait until the WorkerProc is ready.
                     unready_proc_handle = pipes.pop(pipe)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1384,7 +1384,7 @@ class Worker(WorkerBase):
         # Release kept-alive cumem pools while the pluggable allocator wrappers
         # and callbacks are still alive, so MemPool teardown is not deferred to
         # interpreter finalization (pytorch/pytorch#145168).
-        if current_platform.is_cuda_alike():
+        if current_platform.is_cuda_alike() and os.name != "nt":
             from vllm.device_allocator.cumem import CuMemAllocator
 
             if CuMemAllocator.instance is not None:


### PR DESCRIPTION
## Summary

- accept Windows `PipeConnection` handles during worker startup
- avoid POSIX-only `os.sched_yield` and CuMem teardown paths on Windows
- request cooperative EngineCore shutdown before Windows `TerminateProcess`
- add isolated unit coverage for cooperative and unchanged POSIX shutdown paths

This moves required Windows host behavior into `vLLM_for_AMD`, so the Direct-RCCL/D3D12 repository can remain an external platform/communicator plugin without patching vLLM source.

## Validation

- `ruff check` / `ruff format`
- mypy Python 3.10 hook
- SPDX, typos, lazy-import, forbidden-import, Torch accelerator, config, and boolean-context policy hooks
- `pytest --confcutdir=tests/v1/engine -q tests/v1/engine/test_windows_process_compat.py` (2 passed)
- source was based on merged v0.28/ROCm 10 commit `5dbe22c0662c0f34145b5a515009fccaded227e4`

## Runtime status

The v0.28/ROCm 10 native extensions and one-GPU HIP import/tensor probe passed before this Python-only follow-up. TP=2 runtime revalidation is intentionally not claimed in this PR because Windows currently reports the second R9700 as `CM_PROB_FAILED_ADD`; the public setup script fails closed on that state.

## AI assistance disclosure

OpenAI Codex assisted with implementation and test execution. The source and diff were reviewed before submission.