### PR TITLE
Add Windows ROCm compile and MLA fallbacks

### DIFF
--- a/tests/compile/test_compile_ranges.py
+++ b/tests/compile/test_compile_ranges.py
@@ -14,6 +14,7 @@ from vllm.compilation.passes.inductor_pass import (
     InductorPass,
     get_pass_context,
 )
+from vllm.compilation.piecewise_backend import PiecewiseBackend, RangeEntry
 from vllm.config import (
     VllmConfig,
     set_current_vllm_config,
@@ -125,6 +126,18 @@ def test_compile_config_get_compile_ranges():
         Range(start=9, end=32),
         Range(start=33, end=8192),
     ]
+
+
+def test_find_compile_range_without_concrete_compile_sizes():
+    """Dynamic ranges remain usable when compile_sizes is unset (O1)."""
+    compile_range = Range(start=1, end=511)
+    range_entry = RangeEntry(compile_range=compile_range, compiled=True)
+    backend = object.__new__(PiecewiseBackend)
+    backend.compile_sizes = None
+    backend.compile_ranges = [compile_range]
+    backend.range_entries = {compile_range: range_entry}
+
+    assert backend._find_range_for_shape(511) is range_entry
 
 
 class PostGradStaticShapeChecker(InductorPass):

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -158,6 +158,7 @@ def test_mla_post_load_preserves_runtime_weight_addresses(monkeypatch):
 # Validate parameter combinations during collection, before GPU fixtures run.
 PREFILL_BACKENDS_TO_TEST = [
     MLAPrefillBackendEnum.ROCM_AITER_FA,
+    MLAPrefillBackendEnum.TRITON_MLA,
     MLAPrefillBackendEnum.FLASH_ATTN,
     MLAPrefillBackendEnum.FLASHINFER,
     MLAPrefillBackendEnum.TRTLLM_RAGGED,

--- a/tests/v1/attention/test_mla_prefill_registry.py
+++ b/tests/v1/attention/test_mla_prefill_registry.py
@@ -172,3 +172,12 @@ def test_rocm_aiter_fa_registered():
     # The AITER FA path is the fp16/bf16 generic-varlen prefill path.
     assert backend_cls.supports_dtype(torch.bfloat16)
     assert backend_cls.supports_dtype(torch.float16)
+
+
+def test_triton_mla_registered():
+    assert "TRITON_MLA" in MLAPrefillBackendEnum.__members__
+    path = MLAPrefillBackendEnum.TRITON_MLA.get_path()
+    assert path == (
+        "vllm.v1.attention.backends.mla.prefill.triton_mla.TritonMLAPrefillBackend"
+    )
+    assert MLAPrefillBackendEnum.TRITON_MLA.get_class().get_name() == "TRITON_MLA"

--- a/tests/v1/attention/test_mla_prefill_selector.py
+++ b/tests/v1/attention/test_mla_prefill_selector.py
@@ -297,7 +297,7 @@ class TestROCmAiterFAPrefillSelection:
     """Tests for the ROCm AITER FlashAttention MLA prefill backend."""
 
     def test_rocm_priorities_prefer_aiter_fa(self):
-        """On ROCm, ROCM_AITER_FA is tried first, FLASH_ATTN as fallback."""
+        """Prefer AITER/FlashAttention before the portable Triton fallback."""
         with patch("vllm.platforms.current_platform") as mock_platform:
             mock_platform.is_rocm.return_value = True
             priorities = _get_mla_prefill_backend_priorities(
@@ -312,6 +312,7 @@ class TestROCmAiterFAPrefillSelection:
         assert priorities == [
             MLAPrefillBackendEnum.ROCM_AITER_FA,
             MLAPrefillBackendEnum.FLASH_ATTN,
+            MLAPrefillBackendEnum.TRITON_MLA,
         ]
 
     def test_supported_dtypes_are_fp16_bf16_only(self):

--- a/tests/v1/attention/test_triton_mla_prefill.py
+++ b/tests/v1/attention/test_triton_mla_prefill.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright 2026 Carlo Pasquale
+
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.attention.backends.mla.prefill import triton_mla as triton_mla_module
+from vllm.v1.attention.backends.mla.prefill.triton_mla import triton_mla_prefill
+
+
+def test_context_chunk_uses_current_metadata_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = object.__new__(triton_mla_module.TritonMLAPrefillBackend)
+    backend.scale = 0.5
+    q = torch.empty(2, 1, 4)
+    k = torch.empty(3, 1, 4)
+    v = torch.empty(3, 1, 2)
+    out = torch.empty(2, 1, 2)
+    chunk = SimpleNamespace(
+        query_start_loc=torch.tensor([0, 2]),
+        cu_seq_lens=torch.tensor([0, 3]),
+        max_query_len=2,
+    )
+    expected = (out, torch.empty(1, 2))
+    observed: dict[str, object] = {}
+
+    def fake_prefill(**kwargs):
+        observed.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(triton_mla_module, "triton_mla_prefill", fake_prefill)
+
+    actual = backend.run_prefill_context_chunk(chunk, q, k, v, out=out)
+
+    assert actual is expected
+    assert observed["q_start_loc"] is chunk.query_start_loc
+    assert observed["k_start_loc"] is chunk.cu_seq_lens
+    assert observed["max_query_len"] == chunk.max_query_len
+    assert observed["out"] is out
+
+
+def _reference_attention(q, k, v, q_starts, k_starts, scale, causal):
+    out = torch.empty(
+        (q.shape[0], q.shape[1], v.shape[-1]), dtype=v.dtype, device=q.device
+    )
+    lse = torch.empty((q.shape[1], q.shape[0]), dtype=torch.float32, device=q.device)
+    for seq_idx in range(q_starts.numel() - 1):
+        qs, qe = q_starts[seq_idx : seq_idx + 2].tolist()
+        ks, ke = k_starts[seq_idx : seq_idx + 2].tolist()
+        q_seq = q[qs:qe].transpose(0, 1).float()
+        k_seq = k[ks:ke].transpose(0, 1).float()
+        v_seq = v[ks:ke].transpose(0, 1).float()
+        scores = torch.matmul(q_seq, k_seq.transpose(-1, -2)) * scale
+        if causal:
+            q_pos = torch.arange(qe - qs, device=q.device) + (ke - ks) - (qe - qs)
+            k_pos = torch.arange(ke - ks, device=q.device)
+            scores.masked_fill_(q_pos[:, None] < k_pos[None, :], -math.inf)
+        lse[:, qs:qe] = torch.logsumexp(scores, dim=-1)
+        out[qs:qe] = (
+            torch.matmul(torch.softmax(scores, dim=-1), v_seq)
+            .transpose(0, 1)
+            .to(v.dtype)
+        )
+    return out, lse
+
+
+@pytest.mark.skipif(
+    not current_platform.is_rocm() or not torch.accelerator.is_available(),
+    reason="requires a ROCm GPU",
+)
+@pytest.mark.parametrize(
+    ("q_lens", "k_lens", "causal"),
+    [([5, 3], [5, 3], True), ([5, 3], [7, 2], False)],
+)
+def test_triton_mla_prefill_matches_torch(q_lens, k_lens, causal):
+    device = torch.device(torch.accelerator.current_accelerator())
+    q_starts = torch.tensor(
+        [0, *torch.tensor(q_lens).cumsum(0).tolist()], device=device
+    )
+    k_starts = torch.tensor(
+        [0, *torch.tensor(k_lens).cumsum(0).tolist()], device=device
+    )
+    torch.manual_seed(1)
+    q = torch.randn(sum(q_lens), 4, 192, dtype=torch.bfloat16, device=device)
+    k = torch.randn(sum(k_lens), 4, 192, dtype=torch.bfloat16, device=device)
+    v = torch.randn(sum(k_lens), 4, 128, dtype=torch.bfloat16, device=device)
+    scale = 192**-0.5
+
+    actual_out, actual_lse = triton_mla_prefill(
+        q,
+        k,
+        v,
+        q_starts,
+        k_starts,
+        max(q_lens),
+        scale,
+        causal,
+        True,
+    )
+    expected_out, expected_lse = _reference_attention(
+        q, k, v, q_starts.cpu(), k_starts.cpu(), scale, causal
+    )
+
+    torch.testing.assert_close(actual_out, expected_out, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(actual_lse, expected_lse, rtol=2e-3, atol=2e-3)

--- a/vllm/compilation/piecewise_backend.py
+++ b/vllm/compilation/piecewise_backend.py
@@ -344,15 +344,11 @@ class PiecewiseBackend:
         # First we try to find the range entry for the concrete compile size
         # If not found, we search for the range entry
         # that contains the runtime shape.
-        if self.compile_sizes is None:
-            return None
-
-        if runtime_shape in self.compile_sizes:
+        if self.compile_sizes is not None and runtime_shape in self.compile_sizes:
             return self.range_entries[Range(start=runtime_shape, end=runtime_shape)]
-        else:
-            for range in self.compile_ranges:
-                if runtime_shape in range:
-                    return self.range_entries[range]
+        for range in self.compile_ranges:
+            if runtime_shape in range:
+                return self.range_entries[range]
         return None
 
     def __call__(self, *args: Any) -> Any:

--- a/vllm/v1/attention/backends/mla/prefill/registry.py
+++ b/vllm/v1/attention/backends/mla/prefill/registry.py
@@ -52,6 +52,9 @@ class MLAPrefillBackendEnum(Enum, metaclass=_MLAPrefillBackendEnumMeta):
         "vllm.v1.attention.backends.mla.prefill.aiter_flash_attn."
         "AiterFlashAttnPrefillBackend"
     )
+    TRITON_MLA = (
+        "vllm.v1.attention.backends.mla.prefill.triton_mla.TritonMLAPrefillBackend"
+    )
     # Placeholder for third-party/custom backends - must be registered before use
     # set to None to avoid alias with other backend, whose value is an empty string
     CUSTOM = None

--- a/vllm/v1/attention/backends/mla/prefill/selector.py
+++ b/vllm/v1/attention/backends/mla/prefill/selector.py
@@ -64,6 +64,7 @@ def _get_mla_prefill_backend_priorities(
         return [
             MLAPrefillBackendEnum.ROCM_AITER_FA,
             MLAPrefillBackendEnum.FLASH_ATTN,
+            MLAPrefillBackendEnum.TRITON_MLA,
         ]
 
     if device_capability.major == 10:  # Blackwell

--- a/vllm/v1/attention/backends/mla/prefill/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/prefill/triton_mla.py
@@ -1,0 +1,323 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright 2026 Carlo Pasquale
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Portable Triton MLA prefill fallback for ROCm.
+
+This backend is intentionally selected after the tuned AITER and
+FlashAttention implementations.  It keeps prefill on the GPU on ROCm devices
+where neither tuned backend supports the device or is installed.  Unlike the
+generic Triton prefill kernel, it supports MLA's different Q/K and V head
+dimensions and can return LSE values for chunked-context merging.
+"""
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON, tl, triton
+from vllm.v1.attention.backends.mla.prefill.base import MLAPrefillBackend
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.model_executor.layers.attention.mla_attention import (
+        MLACommonPrefillMetadata,
+    )
+    from vllm.platforms.interface import DeviceCapability
+
+
+@triton.jit
+def _triton_mla_prefill_kernel(
+    Q,
+    K,
+    V,
+    Out,
+    Lse,
+    QStartLoc,
+    KStartLoc,
+    scale,
+    stride_qt,
+    stride_qh,
+    stride_qd,
+    stride_kt,
+    stride_kh,
+    stride_kd,
+    stride_vt,
+    stride_vh,
+    stride_vd,
+    stride_out_t,
+    stride_oh,
+    stride_od,
+    stride_lseh,
+    stride_lset,
+    KV_GROUP_NUM: tl.constexpr,
+    QK_HEAD_DIM: tl.constexpr,
+    V_HEAD_DIM: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_QK: tl.constexpr,
+    BLOCK_V: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+    RETURN_LSE: tl.constexpr,
+):
+    seq_idx = tl.program_id(0)
+    q_head_idx = tl.program_id(1)
+    q_block_idx = tl.program_id(2)
+    kv_head_idx = q_head_idx // KV_GROUP_NUM
+
+    q_start = tl.load(QStartLoc + seq_idx)
+    q_len = tl.load(QStartLoc + seq_idx + 1) - q_start
+    k_start = tl.load(KStartLoc + seq_idx)
+    k_len = tl.load(KStartLoc + seq_idx + 1) - k_start
+
+    offs_m = q_block_idx * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_qk = tl.arange(0, BLOCK_QK)
+    offs_v = tl.arange(0, BLOCK_V)
+
+    q_ptrs = (
+        Q
+        + (q_start + offs_m[:, None]) * stride_qt
+        + q_head_idx * stride_qh
+        + offs_qk[None, :] * stride_qd
+    )
+    q = tl.load(
+        q_ptrs,
+        mask=(offs_m[:, None] < q_len) & (offs_qk[None, :] < QK_HEAD_DIM),
+        other=0.0,
+    )
+
+    # Scores are kept in base-2 units for Triton's exp2 implementation.
+    m_i = tl.full([BLOCK_M], -float("inf"), dtype=tl.float32)
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, BLOCK_V], dtype=tl.float32)
+
+    end_n = k_len
+    if IS_CAUSAL:
+        # Bottom-right causal alignment also handles q_len != k_len.
+        end_n = tl.minimum(k_len, (q_block_idx + 1) * BLOCK_M + k_len - q_len)
+    end_n = tl.maximum(end_n, 0)
+
+    for start_n in range(0, end_n, BLOCK_N):
+        pos_q = offs_m[:, None] + k_len - q_len
+        pos_k = start_n + offs_n[None, :]
+        valid_k = pos_k < k_len
+        mask = valid_k
+        if IS_CAUSAL:
+            mask &= pos_q >= pos_k
+
+        k_ptrs = (
+            K
+            + (k_start + start_n + offs_n[None, :]) * stride_kt
+            + kv_head_idx * stride_kh
+            + offs_qk[:, None] * stride_kd
+        )
+        k = tl.load(
+            k_ptrs,
+            mask=valid_k & (offs_qk[:, None] < QK_HEAD_DIM),
+            other=0.0,
+        )
+
+        qk = tl.dot(q, k)
+        qk = tl.where(mask, qk * scale * 1.4426950408889634, -float("inf"))
+        m_ij = tl.maximum(m_i, tl.max(qk, axis=1))
+        p = tl.math.exp2(qk - m_ij[:, None])
+        l_ij = tl.sum(p, axis=1)
+        alpha = tl.math.exp2(m_i - m_ij)
+        l_i = l_i * alpha + l_ij
+        acc *= alpha[:, None]
+
+        v_ptrs = (
+            V
+            + (k_start + start_n + offs_n[:, None]) * stride_vt
+            + kv_head_idx * stride_vh
+            + offs_v[None, :] * stride_vd
+        )
+        value = tl.load(
+            v_ptrs,
+            mask=(start_n + offs_n[:, None] < k_len) & (offs_v[None, :] < V_HEAD_DIM),
+            other=0.0,
+        )
+        acc = tl.dot(p.to(value.dtype), value, acc)
+        m_i = m_ij
+
+    has_keys = l_i > 0.0
+    acc /= tl.where(has_keys[:, None], l_i[:, None], 1.0)
+    out_ptrs = (
+        Out
+        + (q_start + offs_m[:, None]) * stride_out_t
+        + q_head_idx * stride_oh
+        + offs_v[None, :] * stride_od
+    )
+    tl.store(
+        out_ptrs,
+        acc,
+        mask=(offs_m[:, None] < q_len) & (offs_v[None, :] < V_HEAD_DIM),
+    )
+
+    if RETURN_LSE:
+        lse = (m_i + tl.log2(l_i)) * 0.6931471805599453
+        lse = tl.where(has_keys, lse, -float("inf"))
+        lse_ptrs = Lse + q_head_idx * stride_lseh + (q_start + offs_m) * stride_lset
+        tl.store(lse_ptrs, lse, mask=offs_m < q_len)
+
+
+def triton_mla_prefill(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    q_start_loc: torch.Tensor,
+    k_start_loc: torch.Tensor,
+    max_query_len: int,
+    scale: float,
+    causal: bool,
+    return_lse: bool,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Run packed variable-length MLA attention without host payload copies."""
+    assert HAS_TRITON
+    assert q.ndim == k.ndim == v.ndim == 3
+    assert q.shape[-1] == k.shape[-1]
+    assert k.shape[1] == v.shape[1]
+    assert q.shape[1] % k.shape[1] == 0
+    assert q_start_loc.ndim == k_start_loc.ndim == 1
+    assert q_start_loc.shape == k_start_loc.shape
+    assert q.device == k.device == v.device
+    assert q_start_loc.device == q.device and k_start_loc.device == q.device
+    assert q.dtype == k.dtype == v.dtype
+
+    if out is None:
+        out = torch.empty(
+            (q.shape[0], q.shape[1], v.shape[-1]),
+            dtype=v.dtype,
+            device=v.device,
+        )
+    else:
+        assert out.shape == (q.shape[0], q.shape[1], v.shape[-1])
+        assert out.device == q.device and out.dtype == v.dtype
+
+    lse = torch.empty((q.shape[1], q.shape[0]), dtype=torch.float32, device=q.device)
+    batch_size = q_start_loc.shape[0] - 1
+    block_m = 64
+    block_n = 64
+    grid = (batch_size, q.shape[1], triton.cdiv(max_query_len, block_m))
+    _triton_mla_prefill_kernel[grid](
+        q,
+        k,
+        v,
+        out,
+        lse,
+        q_start_loc,
+        k_start_loc,
+        scale,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
+        v.stride(0),
+        v.stride(1),
+        v.stride(2),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        lse.stride(0),
+        lse.stride(1),
+        KV_GROUP_NUM=q.shape[1] // k.shape[1],
+        QK_HEAD_DIM=q.shape[-1],
+        V_HEAD_DIM=v.shape[-1],
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        BLOCK_QK=triton.next_power_of_2(q.shape[-1]),
+        BLOCK_V=triton.next_power_of_2(v.shape[-1]),
+        IS_CAUSAL=causal,
+        RETURN_LSE=return_lse,
+        num_warps=4,
+        num_stages=1,
+    )
+    return (out, lse) if return_lse else out
+
+
+class TritonMLAPrefillBackend(MLAPrefillBackend):
+    """Correctness-first GPU MLA prefill fallback for ROCm."""
+
+    @staticmethod
+    def get_name() -> str:
+        return "TRITON_MLA"
+
+    @classmethod
+    def supports_compute_capability(cls, device_capability: "DeviceCapability") -> bool:
+        return current_platform.is_rocm()
+
+    @classmethod
+    def is_available(cls) -> bool:
+        return current_platform.is_rocm() and HAS_TRITON
+
+    def __init__(
+        self,
+        num_heads: int,
+        scale: float,
+        kv_lora_rank: int,
+        qk_nope_head_dim: int,
+        qk_rope_head_dim: int,
+        v_head_dim: int,
+        vllm_config: "VllmConfig",
+    ) -> None:
+        super().__init__(
+            num_heads=num_heads,
+            scale=scale,
+            kv_lora_rank=kv_lora_rank,
+            qk_nope_head_dim=qk_nope_head_dim,
+            qk_rope_head_dim=qk_rope_head_dim,
+            v_head_dim=v_head_dim,
+            vllm_config=vllm_config,
+        )
+
+    def run_prefill_new_tokens(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        return_softmax_lse: bool,
+        out: torch.Tensor | None = None,
+        output_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        assert output_scale is None, (
+            "TritonMLAPrefillBackend does not support fused quantized output."
+        )
+        return triton_mla_prefill(
+            q=q,
+            k=k,
+            v=v,
+            q_start_loc=self._prefill_metadata.query_start_loc,
+            k_start_loc=self._prefill_metadata.query_start_loc,
+            max_query_len=self._prefill_metadata.max_query_len,
+            scale=self.scale,
+            causal=True,
+            return_lse=return_softmax_lse,
+            out=out,
+        )
+
+    def run_prefill_context_chunk(
+        self,
+        chunk: "MLACommonPrefillMetadata.ContextChunk",
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        out: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        result = triton_mla_prefill(
+            q=q,
+            k=k,
+            v=v,
+            q_start_loc=chunk.query_start_loc,
+            k_start_loc=chunk.cu_seq_lens,
+            max_query_len=chunk.max_query_len,
+            scale=self.scale,
+            causal=False,
+            return_lse=True,
+            out=out,
+        )
+        assert isinstance(result, tuple)
+        return result


### PR DESCRIPTION
## Summary

- keep dynamic O1 compile ranges selectable when `compile_sizes` is unset
- add a correctness-first Triton MLA prefill backend for ROCm devices that cannot use AITER or ROCm FlashAttention
- preserve AITER/FlashAttention priority and use Triton only as the fallback
- support the v0.28 `ContextChunk` interface, unequal Q/K versus V head dimensions, causal packed prefill, chunked context, and LSE output

These are the final generally useful items from the private plugin's old v0.27 patch queue. Landing them in the Windows host fork lets the Direct-RCCL/D3D12 package remain external and stop modifying vLLM source.

## Validation

- dynamic compile-range regression: 1 passed
- Triton registry and ROCm selection tests: 2 passed
- Triton API/numerical tests on one R9700/gfx1201: 3 passed
- guarded numerical kernel run: 2 passed, peak dedicated VRAM 2.45 GiB
- ruff, format, typos, mypy Python 3.10, SPDX, lazy-import, forbidden-import, Torch accelerator, config, and boolean-context hooks passed

## Runtime scope

The numerical Triton kernels were exercised on GPU 0. TP=2 is not claimed here because Windows currently reports GPU 1 as `CM_PROB_FAILED_ADD`; setup remains fail-closed until both adapters are healthy.

## AI assistance disclosure

OpenAI Codex assisted with the v0.28 interface adaptation and test execution. The source and diff were reviewed before submission.